### PR TITLE
Update datadog http_url check URL to v2

### DIFF
--- a/ansible/monitoring.yml
+++ b/ansible/monitoring.yml
@@ -39,7 +39,7 @@
         init_config:
         instances:
           - name: API
-            url: "http://localhost:3013/v2/top"
+            url: "{{ api_base_uri }}/top"
             # Default is false, i.e. emit events instead of service checks.
             # Recommend to set to true.
             skip_event: true

--- a/ansible/monitoring.yml
+++ b/ansible/monitoring.yml
@@ -39,7 +39,7 @@
         init_config:
         instances:
           - name: API
-            url: "http://localhost:3013/v1/top"
+            url: "http://localhost:3013/v2/top"
             # Default is false, i.e. emit events instead of service checks.
             # Recommend to set to true.
             skip_event: true

--- a/deploy.sh
+++ b/deploy.sh
@@ -15,5 +15,5 @@ ansible-galaxy install -r requirements.yml
 ansible-playbook environments.yml
 ansible-playbook --limit=epoch setup.yml
 # split monitoring playbook by environment because Ansible group vars are merged otherwise
-ansible-playbook --limit='uat:&epoch:!tester' --extra-vars "datadog_api_key=${datadog_api_key:?}" monitoring.yml
+ansible-playbook --limit='uat:&epoch' --extra-vars "datadog_api_key=${datadog_api_key:?}" monitoring.yml
 ansible-playbook --limit='integration:&epoch' --extra-vars "datadog_api_key=${datadog_api_key:?}" monitoring.yml


### PR DESCRIPTION
There is no PT ticket for this. Simple URL update to v2.

Deploy group is also changed because we agreed to add this node to the monitoring some time ago.