### PR TITLE
Replace git and pip with build-essential

### DIFF
--- a/ansible/setup.yml
+++ b/ansible/setup.yml
@@ -78,8 +78,7 @@
         state: installed
         update_cache: yes
       with_items:
-        - git
-        - python-pip
+        - build-essential
       tags:
         - dev-tools
 


### PR DESCRIPTION
We still need `build-essential` to build libsodium, however git and pip and no longer needed.

[PT 154212510](https://www.pivotaltracker.com/story/show/154212510)