### PR TITLE
create static ip

### DIFF
--- a/aws/ae-environment.yml
+++ b/aws/ae-environment.yml
@@ -97,3 +97,6 @@ Resources:
         AvailabilityZones:
           Fn::GetAZs:
             Ref: "AWS::Region"
+
+    EpochElasticIP:
+      Type: "AWS::EC2::EIP"


### PR DESCRIPTION
ref: https://www.pivotaltracker.com/story/show/155658506

so i can create ElasticIP (static ip) in cloud formation template, but there is now way that i will be able to assign it to one of created instances.

there is no way to get instance IP from CF template when creating instances with autoscaling group.

But after creating IP manual assignign this IP do not broke anything in CF template.

