### PR TITLE
Use ansible_host as alternative variable

### DIFF
--- a/ansible/group_vars/tag_role_epoch/vars.yml
+++ b/ansible/group_vars/tag_role_epoch/vars.yml
@@ -2,4 +2,4 @@ config:
   http:
     external:
       port: 3013
-api_base_uri: http://{{ ansible_ssh_host }}:{{ config.http.external.port }}/v2
+api_base_uri: http://{{ ansible_ssh_host|default(ansible_host) }}:{{ config.http.external.port }}/v2

--- a/ansible/tasks/health_check.yml
+++ b/ansible/tasks/health_check.yml
@@ -2,7 +2,7 @@
 - name: Wait epoch node API to boot
   wait_for:
     port: "{{ config.http.external.port }}"
-    host: "{{ ansible_ssh_host }}"
+    host: "{{ ansible_ssh_host|default(ansible_host) }}"
     timeout: 30
   connection: local
 


### PR DESCRIPTION
- ec2 dynamic inventory does not populate ansible_ssh_host as OpenStack inventory script,
but ansible_host. Both are Ansible valid tho.