### PR TITLE
Pt 156838514 aws hostname fix

### DIFF
--- a/aws/ae-environment.yml
+++ b/aws/ae-environment.yml
@@ -87,6 +87,8 @@ Resources:
     EpochServerAutoScalingGroup:
       Type: "AWS::AutoScaling::AutoScalingGroup"
       Properties:
+        TerminationPolicies:
+          - OldestInstance
         AutoScalingGroupName:
           Fn::Sub:
             - "ae-${EnvName}-auto-scaling-group"

--- a/aws/ae-environment.yml
+++ b/aws/ae-environment.yml
@@ -75,6 +75,14 @@ Resources:
         SecurityGroups:
         - !Ref EpochSecurityGroup
         - !Ref ManagementSecurityGroup
+        UserData:
+          Fn::Base64:
+            |+
+            #!/bin/bash
+            REGION=`curl -s http://169.254.169.254/latest/meta-data/public-hostname | awk -F . '{print $2}'`
+            IP=`curl -s http://169.254.169.254/latest/meta-data/public-ipv4`
+            echo "aws-$REGION-$IP" > /etc/hostname
+            hostname "aws-$REGION-$IP"
 
     EpochServerAutoScalingGroup:
       Type: "AWS::AutoScaling::AutoScalingGroup"


### PR DESCRIPTION
PT: https://www.pivotaltracker.com/story/show/156838514

This will not affect any running isntances, this will just update LC in ASG, no other actions will be taken, all new instances will have fixed hostname.
To have it fixed on old hosts, would have to rotate all instances to do this and persist static ip

1. Change manualy ASG to count + 1, static ip to new instance.
2. Change ASG count to count +9, wait for new instances to boot
3. Change ASG count back to 10, oldest instances will be killed.