### PR TITLE
Update datadog agent configuration to v6 syntax

### DIFF
--- a/ansible/monitoring.yml
+++ b/ansible/monitoring.yml
@@ -11,8 +11,9 @@
     datadog_config:
       apm_enabled: false
       use_dogstatsd: true
-      process_agent_enabled: true
-      log_enabled: true
+      process_config:
+        enabled: "true" # has to be set as a string
+      logs_enabled: true
       hostname: "{{ ansible_fqdn }}"
       tags:
         - "platform:{{ datadog_platform }}"


### PR DESCRIPTION
- effectively enabling process monitoring

This has been tested on fast integration n0, both manually and with playbook run.

https://www.pivotaltracker.com/story/show/156378779