### PR TITLE
Fix packer openstack builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,8 @@ FROM alpine:3.8
 # Symlink python to python3 to workaround ansible_python_interpreter issue that need to be set per host.
 # Some of the playbooks run on multiple hosts: local + remote.
 # If it's set in the inventory it will not work when a specific inventory is used.
-RUN apk add --no-cache bash curl unzip make python3 py-cryptography openssh-client \
+# OpenSSL required for a packer workaround: https://github.com/hashicorp/packer/issues/2526
+RUN apk add --no-cache bash curl unzip make python3 py-cryptography openssh-client openssl \
     && ln -s /usr/bin/python3 /usr/bin/python
 
 ENV PACKER_VERSION=1.2.4

--- a/env.list
+++ b/env.list
@@ -7,7 +7,8 @@ OS_IDENTITY_API_VERSION
 OS_INTERFACE
 OS_PASSWORD
 OS_PROJECT_ID
-OS_PROJECT_NAME
 OS_REGION_NAME
-OS_USER_DOMAIN_NAME
 OS_USERNAME
+# Packer compatibility: it support only tenant related vars
+# https://www.packer.io/docs/builders/openstack.html#tenant_id
+OS_TENANT_ID


### PR DESCRIPTION
As our openstack provider updated their version we faced packer SSH keys issue https://github.com/hashicorp/packer/issues/2526
This installs openssl to allow the workaround in the upsteam fix.

This also exposes OS_TENANT_ID to docker environment as the OS_PROJECT_ID is not supported by packer.