### PR TITLE
Fix default HTTP check URL

### DIFF
--- a/ansible/monitoring.yml
+++ b/ansible/monitoring.yml
@@ -44,7 +44,7 @@
         init_config:
         instances:
           - name: API
-            url: "{{ api_base_uri|default('127.0.0.1') }}/top"
+            url: "{{ api_base_uri|default('http://127.0.0.1:3013/v2') }}/top"
             # Default is false, i.e. emit events instead of service checks.
             # Recommend to set to true.
             skip_event: true


### PR DESCRIPTION
The default URL is used when pre-building instance images.

relates to: https://www.pivotaltracker.com/story/show/159518269 and https://www.pivotaltracker.com/story/show/159491502

I didn't confirmed yet, but invalid URL in this checks cause datadog error, which in turn might prevent sending other metrics as well.