### PR TITLE
Disable serial/rolling deployments

### DIFF
--- a/ansible/deploy.yml
+++ b/ansible/deploy.yml
@@ -27,7 +27,6 @@
   # Facts are already collected in the previous playbook
   gather_facts: no
   max_fail_percentage: 25
-  serial: "25%"
 
   vars:
     project_root: "{{ ansible_env.HOME }}/node"


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/159500501

I don't think we need rolling/serial deployments as of now after we introduced two phase manual UAT deployments.

Disabling the serial deployments should speedup the total deployment time a bit.