### PR TITLE
Bump epoch version to 0.19

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -38,7 +38,7 @@ module "aws_deploy-ap-southeast-1" {
   instance_type = "m4.large"
 
   epoch = {
-    version = "0.18.0"
+    version = "0.19.0"
 
     # The string must be bash escaped
     beneficiary = "ak\\$tjnw1KcmnwfqXvhtGa9GRjanbHM3t6PmEWEWtNMM3ouvNKRu5"
@@ -61,7 +61,7 @@ module "aws_deploy-eu-central-1" {
   instance_type = "m4.large"
 
   epoch = {
-    version = "0.18.0"
+    version = "0.19.0"
 
     # The string must be bash escaped
     beneficiary = "ak\\$tjnw1KcmnwfqXvhtGa9GRjanbHM3t6PmEWEWtNMM3ouvNKRu5"
@@ -84,7 +84,7 @@ module "aws_deploy-us-west-2" {
   instance_type = "m4.large"
 
   epoch = {
-    version = "0.18.0"
+    version = "0.19.0"
 
     # The string must be bash escaped
     beneficiary = "ak\\$tjnw1KcmnwfqXvhtGa9GRjanbHM3t6PmEWEWtNMM3ouvNKRu5"


### PR DESCRIPTION
A manual bump for now to sync with the UAT state and tracking issue to use latest version is: https://www.pivotaltracker.com/story/show/159699819