### PR TITLE
Fix AMI names to use compatible image builds

### DIFF
--- a/terraform/modules/cloud/aws/deploy/fleet/main.tf
+++ b/terraform/modules/cloud/aws/deploy/fleet/main.tf
@@ -6,7 +6,7 @@ data "aws_ami" "ami" {
 
   filter {
     name   = "name"
-    values = ["epoch-ubuntu-16.04-v1534406182"]
+    values = ["epoch-ubuntu-16.04-v1536651794"]
   }
 
   owners = ["self"]


### PR DESCRIPTION
I forgot to update the AMI image names with compatible images in https://github.com/aeternity/infrastructure/pull/94

The AWS images (AMIs) are already rebuild in https://circleci.com/gh/aeternity/infrastructure/2597