### PR TITLE
Remove datadog explicit hostname configuration

### DIFF
--- a/ansible/monitoring.yml
+++ b/ansible/monitoring.yml
@@ -49,7 +49,6 @@
       process_config:
         enabled: "true" # has to be set as a string
       logs_enabled: true
-      hostname: "{{ ansible_fqdn }}"
       tags:
         - "platform:{{ platform|default('os') }}"
         - "region:{{ region|default('eu-east') }}"


### PR DESCRIPTION
Explicit hostname configuration confuses datadog very often because it's
not unique.
Removing explicit configuration will cause datadog autodiscovery to kick
in
https://docs.datadoghq.com/agent/faq/how-datadog-agent-determines-the-hostname/
that's the instance ID usually.