### PR TITLE
Add dev environments to AWS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -185,6 +185,7 @@ workflows:
       - setup_dev1:
           requires:
             - build_check
+            - setup_terraform
           filters:
             branches:
               only: master
@@ -192,6 +193,7 @@ workflows:
       - setup_dev2:
           requires:
             - build_check
+            - setup_terraform
           filters:
             branches:
               only: master
@@ -223,8 +225,12 @@ workflows:
             - setup_terraform
       - setup_integration
       - setup_fast_integration
-      - setup_dev1
-      - setup_dev2
+      - setup_dev1:
+          requires:
+            - setup_terraform
+      - setup_dev2:
+          requires:
+            - setup_terraform
 
   hourly_seeds_check:
     triggers:

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -19,6 +19,12 @@ provider "aws" {
 }
 
 provider "aws" {
+  version = "1.24"
+  region  = "eu-west-2"
+  alias   = "eu-west-2"
+}
+
+provider "aws" {
   version                 = "1.24"
   region                  = "us-west-2"
   alias                   = "us-west-2"
@@ -86,5 +92,41 @@ module "aws_deploy-us-west-2" {
 
   providers = {
     aws = "aws.us-west-2"
+  }
+}
+
+module "aws_deploy-dev1-eu-west-2" {
+  source            = "modules/cloud/aws/deploy"
+  env               = "dev1"
+  bootstrap_version = "master"
+
+  spot_nodes    = 2
+  spot_price    = "0.125"
+  instance_type = "m4.large"
+
+  epoch = {
+    package = "https://s3.eu-central-1.amazonaws.com/aeternity-epoch-builds/epoch-latest-ubuntu-x86_64.tar.gz"
+  }
+
+  providers = {
+    aws = "aws.eu-west-2"
+  }
+}
+
+module "aws_deploy-dev2-eu-west-2" {
+  source            = "modules/cloud/aws/deploy"
+  env               = "dev2"
+  bootstrap_version = "master"
+
+  spot_nodes    = 2
+  spot_price    = "0.125"
+  instance_type = "m4.large"
+
+  epoch = {
+    package = "https://s3.eu-central-1.amazonaws.com/aeternity-epoch-builds/epoch-latest-ubuntu-x86_64.tar.gz"
+  }
+
+  providers = {
+    aws = "aws.eu-west-2"
   }
 }


### PR DESCRIPTION
completes https://www.pivotaltracker.com/story/show/160448926

after https://github.com/aeternity/infrastructure/pull/109, https://github.com/aeternity/infrastructure/pull/110

Successful deploy: https://circleci.com/gh/aeternity/epoch/33125 (note that openstack is off due to https://github.com/aeternity/infrastructure/pull/112, thus only AWS nodes has been deployed).