### PR TITLE
Downgrade ansible to 2.6.3 because of regression

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-ansible ~= 2.5
+ansible == 2.6.3
 ansible-lint ~= 3.4
 python-openstackclient ~= 3.12
 python-heatclient ~= 1.12


### PR DESCRIPTION
- Ansible 2.6.4 introduces openstack inventory cache related issue, see
https://github.com/ansible/ansible/issues/45431 for details