### PR TITLE
Add integration and fast_integration environments to AWS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,7 +118,6 @@ jobs:
     environment:
       - DEPLOY_ENV: integration
     steps:
-      - *setup_infra
       - *setup_node
       - *setup_monitoring
       - *fail_notification
@@ -128,7 +127,6 @@ jobs:
     environment:
       - DEPLOY_ENV: fast_integration
     steps:
-      - *setup_infra
       - *setup_node
       - *setup_monitoring
       - *fail_notification
@@ -203,6 +201,7 @@ workflows:
       - setup_integration:
           requires:
             - build_check
+            - setup_terraform
           filters:
             branches:
               only: master
@@ -210,6 +209,7 @@ workflows:
       - setup_fast_integration:
           requires:
             - build_check
+            - setup_terraform
           filters:
             branches:
               only: master
@@ -255,12 +255,16 @@ workflows:
       - setup_uat:
           requires:
             - setup_terraform
-      - setup_integration
-      - setup_fast_integration
       - setup_dev1:
           requires:
             - setup_terraform
       - setup_dev2:
+          requires:
+            - setup_terraform
+      - setup_integration:
+          requires:
+            - setup_terraform
+      - setup_fast_integration:
           requires:
             - setup_terraform
 

--- a/ansible/vars/epoch/integration.yml
+++ b/ansible/vars/epoch/integration.yml
@@ -1,12 +1,14 @@
 datadog_enabled: yes
 api_base_uri: http://{{ public_ipv4 }}:{{ epoch_config.http.external.port }}/v2
+genesis_accounts:
+  "ak_UAzhn9rAQg568v6Hwt3w2HPaQb9X9Nw6JbLmnv7trhmGmWGGp": 100000000001
 configure_peers: false
 
 epoch_config:
   peers:
-    - "aenode://pp_2FZr4K4QzbmfBnH8XonUL7A5xR8ChHudSBDnCaPpC5rZAZQAz2@31.13.249.3:3015"
-    - "aenode://pp_2R3XW8C5MCTULnHjcPiWDwLMLT51B4CCgNvHwK9m41Pa3KF3h9@31.13.249.4:3015"
-    - "aenode://pp_ttZZwTS2nzxg7pnEeFMWeRCfdvdxeRu6SgVyeALZX3LbdeWiS@31.13.249.5:3015"
+    - "aenode://pp_PVNHha6SBXQBdh8XsiAma2auMjyDodZAY7BGjd8xir6g6JPBM@31.13.249.71:3015"
+    - "aenode://pp_Hj8oJx1oESu6QNEVLc1K63jezfj61B4SmuyhF5RWfJACaZgry@31.13.249.72:3015"
+    - "aenode://pp_2Jx7N2qDUqu3ZNfd831Byiq4WofebBsSRHNTD79Tcsr9VTTt54@31.13.249.73:3015"
 
   sync:
     port: 3015
@@ -15,14 +17,7 @@ epoch_config:
     external:
       port: 3013
     internal:
-      listen_address: 0.0.0.0
       port: 3113
-    debug: true
-
-  websocket:
-    internal:
-      listen_address: 0.0.0.0
-      port: 3114
 
   keys:
     dir: keys
@@ -34,15 +29,14 @@ epoch_config:
 
   mining:
     beneficiary: "ak_2VoAhMd7tVJrDYM5vPJwFRjueZyirDJumVJNeBWL9j1eNTHsRx"
-    expected_mine_rate: 15000
     cuckoo:
       miner:
-        executable: "{{ ('amazon' in ansible_bios_version) | ternary('mean16s-avx2', 'mean16s-generic')  }}"
+        executable: "{{ ('amazon' in ansible_bios_version) | ternary('mean30s-avx2', 'mean30s-generic')  }}"
         extra_args: "-t {{ ansible_processor_vcpus }}"
-        node_bits: 16
+        node_bits: 30
 
   logging:
-    level: warning
+    level: debug
 
   metrics:
       # StatsD server and port

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -130,3 +130,41 @@ module "aws_deploy-dev2-eu-west-2" {
     aws = "aws.eu-west-2"
   }
 }
+
+module "aws_deploy-integration-eu-west-2" {
+  source            = "modules/cloud/aws/deploy"
+  env               = "integration"
+  bootstrap_version = "master"
+
+  static_nodes  = 1
+  spot_nodes    = 2
+  spot_price    = "0.125"
+  instance_type = "m4.large"
+
+  epoch = {
+    package = "https://s3.eu-central-1.amazonaws.com/aeternity-epoch-builds/epoch-latest-ubuntu-x86_64.tar.gz"
+  }
+
+  providers = {
+    aws = "aws.eu-west-2"
+  }
+}
+
+module "aws_deploy-fast_integration-eu-west-2" {
+  source            = "modules/cloud/aws/deploy"
+  env               = "fast_integration"
+  bootstrap_version = "master"
+
+  static_nodes  = 1
+  spot_nodes    = 2
+  spot_price    = "0.125"
+  instance_type = "m4.large"
+
+  epoch = {
+    package = "https://s3.eu-central-1.amazonaws.com/aeternity-epoch-builds/epoch-latest-ubuntu-x86_64.tar.gz"
+  }
+
+  providers = {
+    aws = "aws.eu-west-2"
+  }
+}


### PR DESCRIPTION
In scope of https://www.pivotaltracker.com/story/show/160448898 and https://www.pivotaltracker.com/story/show/160448903

**depends on https://github.com/aeternity/infrastructure/pull/111 (new AWS region provider)**

This PR turns off peers auto-discovery for integration and fast_integration environments while adding current peers (running on Openstack) as seed peers. It also introduces a static node per each environment (compared to current setup).

To make it more clear, once this is merged in scope of https://www.pivotaltracker.com/story/show/160761831 the peer keypair of the static node will be setup for respective environments, and the seed peer list will be changed to include only that peer_key/node address.