### PR TITLE
Add 20 UAT nodes to AWS

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -39,7 +39,7 @@ module "aws_deploy-ap-southeast-1" {
   bootstrap_version = "v1.1"
 
   static_nodes = 1
-  spot_nodes   = 9
+  spot_nodes   = 14
 
   spot_price    = "0.125"
   instance_type = "m4.large"
@@ -81,7 +81,7 @@ module "aws_deploy-us-west-2" {
   bootstrap_version = "v1.1"
 
   static_nodes = 1
-  spot_nodes   = 9
+  spot_nodes   = 14
 
   spot_price    = "0.125"
   instance_type = "m4.large"
@@ -92,6 +92,27 @@ module "aws_deploy-us-west-2" {
 
   providers = {
     aws = "aws.us-west-2"
+  }
+}
+
+module "aws_deploy-uat-eu-west-2" {
+  source            = "modules/cloud/aws/deploy"
+  env               = "uat"
+  color             = "green"
+  bootstrap_version = "v1.1"
+
+  static_nodes = 1
+  spot_nodes   = 9
+
+  spot_price    = "0.125"
+  instance_type = "m4.large"
+
+  epoch = {
+    package = "https://s3.eu-central-1.amazonaws.com/aeternity-epoch-releases/epoch-latest-ubuntu-x86_64.tar.gz"
+  }
+
+  providers = {
+    aws = "aws.eu-west-2"
   }
 }
 


### PR DESCRIPTION
Group aggregates:
- US West: 15
- Asia Pacific: 15
- EU Central: 10
- EU West: 10
- Green: 25
- Blue: 25

PT: https://www.pivotaltracker.com/story/show/160750385

Follow-up PR to remove OpenStack nodes: https://github.com/aeternity/infrastructure/pull/117