### PR TITLE
Add AWS inventory region group

### DIFF
--- a/ansible/inventory/aws.aws_ec2.yml
+++ b/ansible/inventory/aws.aws_ec2.yml
@@ -12,3 +12,6 @@ keyed_groups:
   # add hosts to tag_Name_Value groups for each Name/Value tag pair
   - prefix: tag
     key: tags
+  # create a group per region e.g. us_east_2
+  - key: placement.region
+    prefix: region


### PR DESCRIPTION
This would allow better ansible scoping of the inventory e.g. deploy only to us-west-2 region.