### PR TITLE
Add UAT module dependancies

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -72,6 +72,8 @@ module "aws_deploy-eu-central-1" {
   providers = {
     aws = "aws.eu-central-1"
   }
+
+  depends_on = ["${module.aws_deploy-ap-southeast-1.static_node_ips}"]
 }
 
 module "aws_deploy-us-west-2" {
@@ -114,6 +116,8 @@ module "aws_deploy-uat-eu-west-2" {
   providers = {
     aws = "aws.eu-west-2"
   }
+
+  depends_on = ["${module.aws_deploy-us-west-2.static_node_ips}"]
 }
 
 module "aws_deploy-dev1-eu-west-2" {

--- a/terraform/modules/cloud/aws/deploy/fleet/main.tf
+++ b/terraform/modules/cloud/aws/deploy/fleet/main.tf
@@ -105,3 +105,7 @@ resource "aws_autoscaling_group" "spot_fleet" {
     },
   ]
 }
+
+output "static_node_ips" {
+  value = "${aws_eip_association.ip_associate.*.public_ip}"
+}

--- a/terraform/modules/cloud/aws/deploy/main.tf
+++ b/terraform/modules/cloud/aws/deploy/main.tf
@@ -18,3 +18,17 @@ module "aws_fleet" {
 
   epoch = "${var.epoch}"
 }
+
+# Module to module depens_on workaround
+# See https://github.com/hashicorp/terraform/issues/1178#issuecomment-105613781
+# See https://github.com/hashicorp/terraform/issues/10462#issuecomment-285751349
+# See https://github.com/hashicorp/terraform/issues/17101
+resource "null_resource" "dummy_dependency" {
+  triggers {
+    depends_on = "${join(",", var.depends_on)}"
+  }
+}
+
+output "static_node_ips" {
+  value = "${module.aws_fleet.static_node_ips}"
+}

--- a/terraform/modules/cloud/aws/deploy/variable.tf
+++ b/terraform/modules/cloud/aws/deploy/variable.tf
@@ -19,3 +19,13 @@ variable "spot_price" {}
 variable "epoch" {
   type = "map"
 }
+
+# Module to module depens_on workaround
+# See https://github.com/hashicorp/terraform/issues/1178#issuecomment-105613781
+# See https://github.com/hashicorp/terraform/issues/10462#issuecomment-285751349
+# See https://github.com/hashicorp/terraform/issues/17101
+variable "depends_on" {
+  default = []
+
+  type = "list"
+}


### PR DESCRIPTION
While originally the solution was planned to split the configuration and use separate commands to run the provisioning, I find this solution more robust regardless of the used TF workaround.

The dependancy is set per `color` so that at any given time at least one seed node per `color` should be available. That would guarantee at least 2 seed nodes for UAT.

Finishes: https://www.pivotaltracker.com/story/show/160690120