### PR TITLE
Add missing pip dependancy (local aws runs)

### DIFF
--- a/ansible/setup.yml
+++ b/ansible/setup.yml
@@ -114,6 +114,7 @@
         - awscli
         - ansible
         - boto
+        - boto3
         - datadog
       tags:
         - dev-tools


### PR DESCRIPTION
The monitoring playbook autodiscover AWS tags and needs this lib to call the AWS API.