### PR TITLE
Remove password for signing keys.

### DIFF
--- a/ansible/vars/epoch/default.yml
+++ b/ansible/vars/epoch/default.yml
@@ -16,7 +16,7 @@ epoch_config:
 
   keys:
     dir: keys
-    password: secret
+    peer_password: secret
 
   chain:
     persist: true

--- a/ansible/vars/epoch/dev1.yml
+++ b/ansible/vars/epoch/dev1.yml
@@ -12,7 +12,7 @@ epoch_config:
 
   keys:
     dir: keys
-    password: secret
+    peer_password: secret
 
   chain:
     persist: true

--- a/ansible/vars/epoch/fast_integration.yml
+++ b/ansible/vars/epoch/fast_integration.yml
@@ -21,7 +21,7 @@ epoch_config:
 
   keys:
     dir: keys
-    password: secret
+    peer_password: secret
 
   chain:
     persist: true

--- a/ansible/vars/epoch/integration.yml
+++ b/ansible/vars/epoch/integration.yml
@@ -21,7 +21,7 @@ epoch_config:
 
   keys:
     dir: keys
-    password: secret
+    peer_password: secret
 
   chain:
     persist: true

--- a/ansible/vars/epoch/test.yml
+++ b/ansible/vars/epoch/test.yml
@@ -18,7 +18,7 @@ epoch_config:
 
   keys:
     dir: keys
-    password: secret
+    peer_password: secret
 
   chain:
     persist: true

--- a/ansible/vars/epoch/uat.yml
+++ b/ansible/vars/epoch/uat.yml
@@ -18,7 +18,7 @@ epoch_config:
 
   keys:
     dir: keys
-    password: secret
+    peer_password: secret
 
   chain:
     persist: true


### PR DESCRIPTION
Related epoch PR: https://github.com/aeternity/epoch/pull/1681

By default `keys.peer_password` was resuing `keys.password`. That's why i'm renaming key. 