### PR TITLE
Bump bootstrap code version to 1.3

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -40,7 +40,7 @@ module "aws_deploy-ap-southeast-1" {
   source            = "modules/cloud/aws/deploy"
   env               = "uat"
   color             = "blue"
-  bootstrap_version = "v1.2"
+  bootstrap_version = "v1.3"
   vault_role        = "epoch-node"
   vault_addr        = "${var.vault_addr}"
 
@@ -64,7 +64,7 @@ module "aws_deploy-eu-central-1" {
   source            = "modules/cloud/aws/deploy"
   env               = "uat"
   color             = "blue"
-  bootstrap_version = "v1.2"
+  bootstrap_version = "v1.3"
   vault_role        = "epoch-node"
   vault_addr        = "${var.vault_addr}"
 
@@ -90,7 +90,7 @@ module "aws_deploy-us-west-2" {
   source            = "modules/cloud/aws/deploy"
   env               = "uat"
   color             = "green"
-  bootstrap_version = "v1.2"
+  bootstrap_version = "v1.3"
   vault_role        = "epoch-node"
   vault_addr        = "${var.vault_addr}"
 
@@ -114,7 +114,7 @@ module "aws_deploy-uat-eu-west-2" {
   source            = "modules/cloud/aws/deploy"
   env               = "uat"
   color             = "green"
-  bootstrap_version = "v1.2"
+  bootstrap_version = "v1.3"
   vault_role        = "epoch-node"
   vault_addr        = "${var.vault_addr}"
 
@@ -139,7 +139,7 @@ module "aws_deploy-uat-eu-west-2" {
 module "aws_deploy-dev1-eu-west-2" {
   source            = "modules/cloud/aws/deploy"
   env               = "dev1"
-  bootstrap_version = "v1.2"
+  bootstrap_version = "v1.3"
   vault_role        = "epoch-node"
   vault_addr        = "${var.vault_addr}"
 
@@ -181,7 +181,7 @@ module "aws_deploy-dev2-eu-west-2" {
 module "aws_deploy-integration-eu-west-2" {
   source            = "modules/cloud/aws/deploy"
   env               = "integration"
-  bootstrap_version = "v1.2"
+  bootstrap_version = "v1.3"
   vault_role        = "epoch-node"
   vault_addr        = "${var.vault_addr}"
 
@@ -203,7 +203,7 @@ module "aws_deploy-integration-eu-west-2" {
 module "aws_deploy-fast_integration-eu-west-2" {
   source            = "modules/cloud/aws/deploy"
   env               = "fast_integration"
-  bootstrap_version = "v1.2"
+  bootstrap_version = "v1.3"
   vault_role        = "epoch-node"
   vault_addr        = "${var.vault_addr}"
 


### PR DESCRIPTION
I've tested latest master (now v1.3 tag) to bootstrap dev2 and it works as expected. Thus it should be running fine on other environments as well. I also don't see BC breaking changes with UAT epoch code/configuration.