### PR TITLE
Fix UAT bootstrap

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -40,9 +40,10 @@ module "aws_deploy-ap-southeast-1" {
   source            = "modules/cloud/aws/deploy"
   env               = "uat"
   color             = "blue"
-  bootstrap_version = "v1.2"
+  bootstrap_version = "v1.2.1"
   vault_role        = "epoch-node"
   vault_addr        = "${var.vault_addr}"
+  user_data_file    = "user_data_uat.bash"
 
   static_nodes = 1
   spot_nodes   = 14
@@ -64,9 +65,10 @@ module "aws_deploy-eu-central-1" {
   source            = "modules/cloud/aws/deploy"
   env               = "uat"
   color             = "blue"
-  bootstrap_version = "v1.2"
+  bootstrap_version = "v1.2.1"
   vault_role        = "epoch-node"
   vault_addr        = "${var.vault_addr}"
+  user_data_file    = "user_data_uat.bash"
 
   static_nodes = 1
   spot_nodes   = 9
@@ -90,9 +92,10 @@ module "aws_deploy-us-west-2" {
   source            = "modules/cloud/aws/deploy"
   env               = "uat"
   color             = "green"
-  bootstrap_version = "v1.2"
+  bootstrap_version = "v1.2.1"
   vault_role        = "epoch-node"
   vault_addr        = "${var.vault_addr}"
+  user_data_file    = "user_data_uat.bash"
 
   static_nodes = 1
   spot_nodes   = 14
@@ -114,9 +117,10 @@ module "aws_deploy-uat-eu-west-2" {
   source            = "modules/cloud/aws/deploy"
   env               = "uat"
   color             = "green"
-  bootstrap_version = "v1.2"
+  bootstrap_version = "v1.2.1"
   vault_role        = "epoch-node"
   vault_addr        = "${var.vault_addr}"
+  user_data_file    = "user_data_uat.bash"
 
   static_nodes = 1
   spot_nodes   = 9

--- a/terraform/modules/cloud/aws/deploy/fleet/main.tf
+++ b/terraform/modules/cloud/aws/deploy/fleet/main.tf
@@ -48,7 +48,7 @@ resource "aws_launch_configuration" "spot" {
 }
 
 data "template_file" "user_data" {
-  template = "${file("${path.module}/templates/user_data.bash")}"
+  template = "${file("${path.module}/templates/${var.user_data_file}")}"
 
   vars = {
     region            = "${data.aws_region.current.name}"

--- a/terraform/modules/cloud/aws/deploy/fleet/templates/user_data_uat.bash
+++ b/terraform/modules/cloud/aws/deploy/fleet/templates/user_data_uat.bash
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# Don't enable debug mode in this script if secrets are managed as it ends-up in the logs
+# set -x
+exec > >(tee /tmp/user-data.log|logger -t user-data ) 2>&1
+
+export INFRASTRUCTURE_ANSIBLE_VAULT_PASSWORD=`aws --region ${region} secretsmanager get-secret-value --secret-id ansible_vault_password --output text --query 'SecretString'`
+
+git clone -b ${bootstrap_version} --single-branch https://github.com/aeternity/infrastructure.git /infrastructure
+cd /infrastructure/ansible
+
+# Install ansible roles
+ansible-galaxy install -r requirements.yml
+
+# Create temporary inventory just because of the group_vars
+cat > /tmp/local_inventory << EOF
+[local]
+localhost ansible_connection=local
+
+[tag_role_epoch:children]
+local
+
+[tag_env_${env}:children]
+local
+
+EOF
+
+ansible-playbook \
+    -i inventory/vault.yml \
+    -i /tmp/local_inventory \
+    -e env=${env} \
+    monitoring.yml
+
+ansible-playbook \
+    -i inventory/vault.yml \
+    -i /tmp/local_inventory \
+    --become-user epoch -b \
+    -e package=${epoch_package} \
+    -e env=${env} \
+    -e db_version=0 \
+    deploy.yml

--- a/terraform/modules/cloud/aws/deploy/fleet/variables.tf
+++ b/terraform/modules/cloud/aws/deploy/fleet/variables.tf
@@ -27,3 +27,5 @@ variable "ami_name" {}
 variable "vault_addr" {}
 
 variable "vault_role" {}
+
+variable "user_data_file" {}

--- a/terraform/modules/cloud/aws/deploy/main.tf
+++ b/terraform/modules/cloud/aws/deploy/main.tf
@@ -15,6 +15,7 @@ module "aws_fleet" {
   ami_name          = "${var.ami_name}"
   vault_addr        = "${var.vault_addr}"
   vault_role        = "${var.vault_role}"
+  user_data_file    = "${var.user_data_file}"
 
   spot_nodes   = "${var.spot_nodes}"
   static_nodes = "${var.static_nodes}"

--- a/terraform/modules/cloud/aws/deploy/variable.tf
+++ b/terraform/modules/cloud/aws/deploy/variable.tf
@@ -35,3 +35,7 @@ variable "ami_name" {}
 variable "vault_addr" {}
 
 variable "vault_role" {}
+
+variable "user_data_file" {
+  default = "user_data.bash"
+}


### PR DESCRIPTION
Multiple BC incompatible changes both in epoch and infrastructure
configuration caused UAT bootstrap issues.

v1.2.1 branch is slice just before the infrastructure BC breaks but
including the epoch configuration changes (peer_password).

A separate user_data file is used only for UAT.

Both changes should be temporary.