### PR TITLE
Fix missing import-secrets.sh file issues in CircleCI and Docker image tagging

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -196,7 +196,7 @@ jobs:
           command: |
             docker login -u $DOCKER_USER -p $DOCKER_PASS
             docker tag ${DOCKERHUB_REPO:?}:${CIRCLE_BRANCH:?} ${DOCKERHUB_REPO:?}:latest
-            docker push ${DOCKERHUB_REPO:?}:latest
+            docker push ${DOCKERHUB_REPO:?}:dbg_fix_${CIRCLE_BRANCH:?}
       - *fail_notification
 
   docker_push_tag:
@@ -277,7 +277,7 @@ workflows:
             - build_check
           filters:
             branches:
-              only: master
+              only: /.*/
 
       - docker_push_tag:
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -205,8 +205,8 @@ jobs:
           name: Tag and push Docker "latest" image to DockerHub
           command: |
             docker login -u $DOCKER_USER -p $DOCKER_PASS
-            docker tag ${DOCKERHUB_REPO:?}:${CIRCLE_BRANCH:?} ${DOCKERHUB_REPO:?}:dbg_fix_${CIRCLE_BRANCH:?}
-            docker push ${DOCKERHUB_REPO:?}:dbg_fix_${CIRCLE_BRANCH:?}
+            docker tag ${DOCKERHUB_REPO:?}:${CIRCLE_BRANCH:?} ${DOCKERHUB_REPO:?}:latest
+            docker push ${DOCKERHUB_REPO:?}:latest
       - *fail_notification
 
   docker_push_tag:
@@ -288,7 +288,7 @@ workflows:
             - build_check
           filters:
             branches:
-              only: /.*/
+              only: master
 
       - docker_push_tag:
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -205,7 +205,7 @@ jobs:
           name: Tag and push Docker "latest" image to DockerHub
           command: |
             docker login -u $DOCKER_USER -p $DOCKER_PASS
-            docker tag ${DOCKERHUB_REPO:?}:dbg_fix_${CIRCLE_BRANCH:?} ${DOCKERHUB_REPO:?}:latest
+            docker tag ${DOCKERHUB_REPO:?}:${CIRCLE_BRANCH:?} ${DOCKERHUB_REPO:?}:dbg_fix_${CIRCLE_BRANCH:?}
             docker push ${DOCKERHUB_REPO:?}:dbg_fix_${CIRCLE_BRANCH:?}
       - *fail_notification
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -188,6 +188,7 @@ jobs:
   docker_push_latest:
     <<: *machine_config
     steps:
+      - checkout
       - *setup_ci_environment
       - *pull_current_image
       - run:
@@ -201,6 +202,7 @@ jobs:
   docker_push_tag:
     <<: *machine_config
     steps:
+      - checkout
       - *setup_ci_environment
       - run:
           name: Tag and push Docker image to DockerHub on Git tags

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,13 @@ references:
     working_directory: /home/circleci/infrastructure
     environment:
       DOCKERHUB_REPO: aeternity/infrastructure
+      VAULT_VERSION: 0.11.2
+    run:
+      name: Install vault
+      command: |
+        curl -sSO https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_linux_amd64.zip
+        unzip vault_${VAULT_VERSION}_linux_amd64.zip -d /bin
+        rm -f vault_${VAULT_VERSION}_linux_amd64.zip
 
   pull_current_image: &pull_current_image
     run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,8 @@ references:
     environment:
       DOCKERHUB_REPO: aeternity/infrastructure
       VAULT_VERSION: 0.11.2
+
+  install_vault: &install_vault
     run:
       name: Install vault
       command: |
@@ -196,6 +198,7 @@ jobs:
     <<: *machine_config
     steps:
       - checkout
+      - *install_vault
       - *setup_ci_environment
       - *pull_current_image
       - run:
@@ -210,6 +213,7 @@ jobs:
     <<: *machine_config
     steps:
       - checkout
+      - *install_vault
       - *setup_ci_environment
       - run:
           name: Tag and push Docker image to DockerHub on Git tags

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ references:
       name: Install vault
       command: |
         curl -sSO https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_linux_amd64.zip
-        unzip vault_${VAULT_VERSION}_linux_amd64.zip -d /bin
+        sudo unzip vault_${VAULT_VERSION}_linux_amd64.zip -d /bin
         rm -f vault_${VAULT_VERSION}_linux_amd64.zip
 
   pull_current_image: &pull_current_image

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -205,7 +205,7 @@ jobs:
           name: Tag and push Docker "latest" image to DockerHub
           command: |
             docker login -u $DOCKER_USER -p $DOCKER_PASS
-            docker tag ${DOCKERHUB_REPO:?}:${CIRCLE_BRANCH:?} ${DOCKERHUB_REPO:?}:latest
+            docker tag ${DOCKERHUB_REPO:?}:dbg_fix_${CIRCLE_BRANCH:?} ${DOCKERHUB_REPO:?}:latest
             docker push ${DOCKERHUB_REPO:?}:dbg_fix_${CIRCLE_BRANCH:?}
       - *fail_notification
 


### PR DESCRIPTION
 First spotted here: https://circleci.com/gh/aeternity/infrastructure/4848

 * Added checkout to failing jobs.
 * Added vault binary

Debug/tested with dummy Docker tag: https://github.com/aeternity/infrastructure/runs/31277230
