### PR TITLE
Fix SSH public key path

### DIFF
--- a/ansible/setup.yml
+++ b/ansible/setup.yml
@@ -59,7 +59,7 @@
 
     - name: Download Vault public key
       get_url:
-        url: "{{ vault_addr }}/v1/ssh-client-signer/public_key"
+        url: "{{ vault_addr }}/v1/ssh/public_key"
         dest: /etc/ssh/trusted-user-ca-keys.pem
       when: vault_addr is defined
       tags:


### PR DESCRIPTION
The playbook was using old SSH authentication path/endpoint, leading to different public key deployed than that [used to sign client keys](https://github.com/aeternity/infrastructure/blob/master/Makefile#L66).