### PR TITLE
Fix ansible AWS checks since 2.7.0 update

### DIFF
--- a/ansible/deploy.yml
+++ b/ansible/deploy.yml
@@ -21,10 +21,22 @@
       # http://docs.ansible.com/ansible/latest/user_guide/playbooks_tags.html#special-tags
       tags: [always]
       when: hosts_group is defined
+
+    - name: Check if running on AWS instance
+      uri:
+        url: http://169.254.169.254/latest/meta-data
+        timeout: 2
+      register: aws_uri_check
+      failed_when: False
+
+    - name: Set AWS check fact
+      set_fact:
+        is_aws: "{{ aws_uri_check.status == 200 }}"
+
     - name: Gather instance metadata facts
       ec2_metadata_facts:
       tags: [always]
-      when: '"amazon" in ansible_bios_version'
+      when: is_aws
 
 - name: Deploy epoch package
   hosts: all

--- a/ansible/monitoring.yml
+++ b/ansible/monitoring.yml
@@ -8,15 +8,26 @@
   gather_facts: yes
   tags: [datadog]
   tasks:
+    - name: Check if running on AWS instance
+      uri:
+        url: http://169.254.169.254/latest/meta-data
+        timeout: 2
+      register: aws_uri_check
+      failed_when: False
+
+    - name: Set AWS check fact
+      set_fact:
+        is_aws: "{{ aws_uri_check.status == 200 }}"
+
     - name: Get instance metadata facts
       ec2_metadata_facts:
-      when: '"amazon" in ansible_bios_version'
+      when: is_aws
 
     - name: Define ec2 dynamic variables
       set_fact:
         platform: aws
         region: "{{ ansible_ec2_placement_region }}"
-      when: '"amazon" in ansible_bios_version'
+      when: is_aws
 
     - name: Get instance tags
       ec2_tag:

--- a/ansible/vars/epoch/default.yml
+++ b/ansible/vars/epoch/default.yml
@@ -26,7 +26,7 @@ epoch_config:
     beneficiary: "ak_2VoAhMd7tVJrDYM5vPJwFRjueZyirDJumVJNeBWL9j1eNTHsRx"
     cuckoo:
       miner:
-        executable: "{{ ('amazon' in ansible_bios_version) | ternary('mean29-avx2', 'mean29-generic')  }}"
+        executable: mean29-generic
         extra_args: "-t {{ ansible_processor_vcpus }}"
         edge_bits: 29
 

--- a/ansible/vars/epoch/fast_integration.yml
+++ b/ansible/vars/epoch/fast_integration.yml
@@ -32,7 +32,7 @@ epoch_config:
     expected_mine_rate: 15000
     cuckoo:
       miner:
-        executable: "{{ ('amazon' in ansible_bios_version) | ternary('mean15-avx2', 'mean15-generic')  }}"
+        executable: mean15-avx2
         extra_args: "-t {{ ansible_processor_vcpus }}"
         edge_bits: 15
 

--- a/ansible/vars/epoch/integration.yml
+++ b/ansible/vars/epoch/integration.yml
@@ -31,7 +31,7 @@ epoch_config:
     beneficiary: "ak_2VoAhMd7tVJrDYM5vPJwFRjueZyirDJumVJNeBWL9j1eNTHsRx"
     cuckoo:
       miner:
-        executable: "{{ ('amazon' in ansible_bios_version) | ternary('mean29-avx2', 'mean29-generic')  }}"
+        executable: mean29-avx2
         extra_args: "-t {{ ansible_processor_vcpus }}"
         edge_bits: 29
 

--- a/ansible/vars/epoch/test.yml
+++ b/ansible/vars/epoch/test.yml
@@ -28,7 +28,7 @@ epoch_config:
     beneficiary: "ak_2VoAhMd7tVJrDYM5vPJwFRjueZyirDJumVJNeBWL9j1eNTHsRx"
     cuckoo:
       miner:
-        executable: "{{ ('amazon' in ansible_bios_version) | ternary('mean29-avx2', 'mean29-generic')  }}"
+        executable: mean29-avx2
         extra_args: "-t {{ ansible_processor_vcpus }}"
         edge_bits: 29
 

--- a/ansible/vars/epoch/uat.yml
+++ b/ansible/vars/epoch/uat.yml
@@ -28,7 +28,7 @@ epoch_config:
     beneficiary: "ak_tjnw1KcmnwfqXvhtGa9GRjanbHM3t6PmEWEWtNMM3ouvNKRu5"
     cuckoo:
       miner:
-        executable: "{{ ('amazon' in ansible_bios_version) | ternary('mean29-avx2', 'mean29-generic')  }}"
+        executable: mean29-avx2
         extra_args: "-t {{ ansible_processor_vcpus }}"
         edge_bits: 29
 


### PR DESCRIPTION
`ansible_bios_version` is no longer relevant after Ansible 2.7

- [x] test it