### PR TITLE
Only use one thread for mining

### DIFF
--- a/ansible/vars/epoch/uat.yml
+++ b/ansible/vars/epoch/uat.yml
@@ -29,7 +29,7 @@ epoch_config:
     cuckoo:
       miner:
         executable: mean29-avx2
-        extra_args: "-t {{ ansible_processor_vcpus }}"
+        extra_args: "-t 1"
         edge_bits: 29
 
   logging:


### PR DESCRIPTION
If we want to perform realistic load test on mining, then having only one of the CPUs on these machines mine, makes sense. In a realistic network, people are advised to keep some CPU available for other tasks than mining. If they don't then they can get overloaded. But if a machine has CPU power available, it should be able to stand up against a lot of load.

Contemplated to just leave 1 CPU available, but realised that 
1) we don't what happens if we would specify "-t 0"
2) we don't care how much mining power we have on uat, 60 mining CPUs seems very reasonable.