### PR TITLE
Use Python3 isntead of Python2

### DIFF
--- a/ansible/deploy.yml
+++ b/ansible/deploy.yml
@@ -28,10 +28,12 @@
         timeout: 2
       register: aws_uri_check
       failed_when: False
+      tags: [always]
 
     - name: Set AWS check fact
       set_fact:
         is_aws: "{{ aws_uri_check.status == 200 }}"
+      tags: [always]
 
     - name: Gather instance metadata facts
       ec2_metadata_facts:

--- a/ansible/files/epoch.fact
+++ b/ansible/files/epoch.fact
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 import subprocess
@@ -9,14 +9,14 @@ node_path = "/home/epoch/node"
 
 def read_node_file_contents(filename):
     try:
-        with file(node_path + "/" + filename) as f:
+        with open(node_path + "/" + filename) as f:
             return f.read().strip()
     except IOError as e:
         return ""
 
 try:
     with open(os.devnull, 'w') as devnull:
-        peer_key = subprocess.check_output(node_path + "/bin/epoch peer_key", shell=True, stderr=devnull)
+        peer_key = str(subprocess.check_output(node_path + "/bin/epoch peer_key", shell=True, stderr=devnull))
 except subprocess.CalledProcessError as exc:
     peer_key = ""
 
@@ -29,9 +29,9 @@ try:
 except IOError as e:
     config = {}
 
-print json.dumps({
+print(json.dumps({
     "version": read_node_file_contents("VERSION"),
     "revision": read_node_file_contents("REVISION"),
     "peer_key": peer_key,
     "config": config,
-})
+}))

--- a/ansible/setup.yml
+++ b/ansible/setup.yml
@@ -84,26 +84,19 @@
         update_cache: yes
         pkg:
         - build-essential
-        - python-yaml
-        - python-pip
+        - python3
+        - python3-yaml #epoch.fact
+        - python3-pip
+        - virtualenv
         - jq
         - unzip
       tags:
         - dev-tools
 
-    - name: Remove conflicting or obsolete packages
-      apt:
-        state: absent
-        pkg:
-        # Ansible paramico has dependency on newer cryptography version which is installed as pip module
-        # The OS package is older and once installed the pip version is not
-        - python-cryptography
-      tags:
-        - dev-tools
-
     - name: Install pip tools
       pip:
-        executable: pip2
+        virtualenv: /var/venv
+        virtualenv_python: python3
         name:
         - awscli
         - ansible


### PR DESCRIPTION
After long debugging of weird ansible behaviour of copy_module that create binary files with unexpected contents, I found out it's because of the python version. I didn't dig deeper what's the exact reason because python2 should be dead already.

https://www.pivotaltracker.com/story/show/162123459