### PR TITLE
Better handling of SSH keys

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
 *
+!docker/ssh_config
 !docker-entrypoint.sh
 !import-secrets.sh
 !ansible

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,8 @@ RUN apk add --no-cache --virtual build-deps \
 ADD ansible/requirements.yml /infrastructure/ansible/
 RUN cd /infrastructure/ansible && ansible-galaxy install -r requirements.yml
 
+ADD docker/ssh_config /etc/ssh/ssh_config
+
 ADD . /infrastructure
 WORKDIR /infrastructure
 

--- a/Makefile
+++ b/Makefile
@@ -62,11 +62,15 @@ mnesia_backup:
 ~/.ssh/id_ae_infra_ed25519:
 	@ssh-keygen -t ed25519 -N "" -f $@
 
+.PRECIOUS: ~/.ssh/id_ae_infra_ed25519-%-cert.pub
 ~/.ssh/id_ae_infra_ed25519-%-cert.pub: ~/.ssh/id_ae_infra_ed25519
 	@vault write -field=signed_key ssh/sign/$* public_key=@$<.pub > $@
 
-ssh-%: ~/.ssh/id_ae_infra_ed25519-%-cert.pub
-	@ssh -i $< -i ~/.ssh/id_ae_infra_ed25519 $*@$(HOST)
+cert-%: ~/.ssh/id_ae_infra_ed25519-%-cert.pub
+	@
+
+ssh-%: cert-%
+	@ssh $*@$(HOST)
 
 ssh: ssh-epoch
 
@@ -97,5 +101,5 @@ clean:
 
 .PHONY: \
 	images setup-terraform setup-node setup-monitoring setup \
-	manage-node reset-net lint ssh-% ssh clean \
+	manage-node reset-net lint cert-% ssh-% ssh clean \
 	check-seed-peers check-deploy-env

--- a/docker/ssh_config
+++ b/docker/ssh_config
@@ -1,0 +1,3 @@
+Host *
+    IdentityFile ~/.ssh/id_ae_infra_ed25519
+    CertificateFile ~/.ssh/id_ae_infra_ed25519-%r-cert.pub


### PR DESCRIPTION
This allows using the ssh keys after their generation to `make cert-epoch` or `make cert-master` as usual (without providing their path to the commands)