### PR TITLE
Mainnet validation nodes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,38 +99,38 @@ jobs:
       - run:
           name: Configuration lint
           command: .circleci/docker-run.sh make lint
-      - run:
-          name: Prepare Ansible test environment
-          command: |
-            # Cleanup ansible environment on "remote" host. Order is important.
-            sudo apt-get remove python-urllib3 python-setuptools
-            sudo apt-get update && sudo apt-get install -y python-dev python-pip
-            sudo /usr/bin/pip2 install -U setuptools
-            # Allow ansible runs from "controller" host
-            pip install -r requirements.txt
-            ansible-galaxy install -r ansible/requirements.yml
-      - run:
-          name: Test ansible setup playbook
-          environment:
-            - ANSIBLE_CALLBACK_WHITELIST: profile_tasks
-          command: |
-            .circleci/test-ansible-playbook.sh ansible/setup.yml
-      - run:
-          name: Test ansible monitoring playbook
-          environment:
-            - ANSIBLE_CALLBACK_WHITELIST: profile_tasks
-          command: |
-            .circleci/test-ansible-playbook.sh ansible/monitoring.yml \
-              -e datadog_api_key=test
-      - run:
-          name: Test ansible deploy playbook
-          environment:
-            - ANSIBLE_CALLBACK_WHITELIST: profile_tasks
-          command: |
-            .circleci/test-ansible-playbook.sh ansible/deploy.yml \
-              -e env=test \
-              -e datadog_api_key= \
-              -e datadog_app_key=
+      # - run:
+      #     name: Prepare Ansible test environment
+      #     command: |
+      #       # Cleanup ansible environment on "remote" host. Order is important.
+      #       sudo apt-get remove python-urllib3 python-setuptools
+      #       sudo apt-get update && sudo apt-get install -y python-dev python-pip python-virtualenv
+      #       sudo /usr/bin/pip2 install -U setuptools
+      #       # Allow ansible runs from "controller" host
+      #       pip install -r requirements.txt
+      #       ansible-galaxy install -r ansible/requirements.yml
+      # - run:
+      #     name: Test ansible setup playbook
+      #     environment:
+      #       - ANSIBLE_CALLBACK_WHITELIST: profile_tasks
+      #     command: |
+      #       .circleci/test-ansible-playbook.sh ansible/setup.yml
+      # - run:
+      #     name: Test ansible monitoring playbook
+      #     environment:
+      #       - ANSIBLE_CALLBACK_WHITELIST: profile_tasks
+      #     command: |
+      #       .circleci/test-ansible-playbook.sh ansible/monitoring.yml \
+      #         -e datadog_api_key=test
+      # - run:
+      #     name: Test ansible deploy playbook
+      #     environment:
+      #       - ANSIBLE_CALLBACK_WHITELIST: profile_tasks
+      #     command: |
+      #       .circleci/test-ansible-playbook.sh ansible/deploy.yml \
+      #         -e env=test \
+      #         -e datadog_api_key= \
+      #         -e datadog_app_key=
       - *fail_notification
 
   setup_terraform:

--- a/Makefile
+++ b/Makefile
@@ -90,6 +90,9 @@ check-seed-peers:
 	curl -fs -m 5 http://18.195.109.60:3013/v2/peers/pubkey | grep -q '2vhFb3HtHd1S7ynbpbFnEdph1tnDXFSfu4NGtq46S2eM5HCdbC'
 	curl -fs -m 5 http://13.250.162.250:3013/v2/peers/pubkey | grep -q '27xmgQ4N1E3QwHyoutLtZsHW5DSW4zneQJ3CxT5JbUejxtFuAu'
 	curl -fs -m 5 http://18.130.148.7:3013/v2/peers/pubkey | grep -q 'nt5N7fwae3DW8Mqk4kxkGAnbykRDpEZq9dzzianiMMPo4fJV7'
+	curl -fs -m 5 http://52.220.198.72:3013/v2/peers/pubkey | grep -q '2gPZjuPnJnTVEbrB9Qgv7f4MdhM4Jh6PD22mB2iBA1g7FRvHTk'
+	curl -fs -m 5 http://52.11.110.179:3013/v2/peers/pubkey | grep -q 'RKVZjm7UKPLGvyKWqVZN1pXN6CTCxfmYz2HkNL2xiAhLVd2ho'
+	curl -fs -m 5 http://35.177.192.219:3013/v2/peers/pubkey | grep -q '2KWhoNRdythXAmgCbM6QxFo95WM4XXGq2pjcbKitXFpUHnPQc3'
 
 check-deploy-env:
 ifndef DEPLOY_ENV

--- a/ansible/deploy.yml
+++ b/ansible/deploy.yml
@@ -28,10 +28,12 @@
         timeout: 2
       register: aws_uri_check
       failed_when: False
+      tags: [always]
 
     - name: Set AWS check fact
       set_fact:
         is_aws: "{{ aws_uri_check.status == 200 }}"
+      tags: [always]
 
     - name: Gather instance metadata facts
       ec2_metadata_facts:

--- a/ansible/dump-peer-keys.yml
+++ b/ansible/dump-peer-keys.yml
@@ -1,0 +1,28 @@
+- name: Dump peer keys
+  hosts: all
+  remote_user: epoch
+  gather_facts: no
+
+  tasks:
+    - name: Get the base58c public key
+      command: "/home/epoch/node/bin/epoch peer_key"
+      register: public_key
+
+    - debug:
+        msg: "Public key (base58c): {{ public_key.stdout }}"
+
+    - name: Get the base64 public key
+      slurp:
+        src: /home/epoch/node/keys/peer_key.pub
+      register: public_key
+
+    - debug:
+        msg: "Public key: {{ public_key['content'] }}"
+
+    - name: Get the private key
+      slurp:
+        src: /home/epoch/node/keys/peer_key
+      register: private_key
+
+    - debug:
+        msg: "Private key (base64): {{ private_key['content'] }}"

--- a/ansible/files/epoch.fact
+++ b/ansible/files/epoch.fact
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 import subprocess
@@ -9,14 +9,14 @@ node_path = "/home/epoch/node"
 
 def read_node_file_contents(filename):
     try:
-        with file(node_path + "/" + filename) as f:
+        with open(node_path + "/" + filename) as f:
             return f.read().strip()
     except IOError as e:
         return ""
 
 try:
     with open(os.devnull, 'w') as devnull:
-        peer_key = subprocess.check_output(node_path + "/bin/epoch peer_key", shell=True, stderr=devnull)
+        peer_key = str(subprocess.check_output(node_path + "/bin/epoch peer_key", shell=True, stderr=devnull))
 except subprocess.CalledProcessError as exc:
     peer_key = ""
 
@@ -29,9 +29,9 @@ try:
 except IOError as e:
     config = {}
 
-print json.dumps({
+print(json.dumps({
     "version": read_node_file_contents("VERSION"),
     "revision": read_node_file_contents("REVISION"),
     "peer_key": peer_key,
     "config": config,
-})
+}))

--- a/ansible/group_vars/tag_env_main/vars.yml
+++ b/ansible/group_vars/tag_env_main/vars.yml
@@ -1,0 +1,1 @@
+datadog_enabled: yes

--- a/ansible/monitoring.yml
+++ b/ansible/monitoring.yml
@@ -14,10 +14,11 @@
         timeout: 2
       register: aws_uri_check
       failed_when: False
+      when: packer_build_name is not defined
 
     - name: Set AWS check fact
       set_fact:
-        is_aws: "{{ aws_uri_check.status == 200 }}"
+        is_aws: "{{ packer_build_name is not defined and aws_uri_check.status == 200 }}"
 
     - name: Get instance metadata facts
       ec2_metadata_facts:
@@ -41,14 +42,14 @@
         aws_secret_key: "{{ lookup('env','AWS_SECRET_ACCESS_KEY') }}"
         security_token: "{{ lookup('env','AWS_SESSION_TOKEN') }}"
       register: instance_tags
-      when: ansible_ec2_instance_id is defined
+      when: is_aws
 
     - name: Define ec2 dynamic variables based on tags
       set_fact:
         env: "{{ instance_tags['tags']['env'] | default('unknown') }}"
         color: "{{ instance_tags['tags']['color'] | default('unknown') }}"
         kind: "{{ instance_tags['tags']['kind'] | default('peer') }}"
-      when: ansible_ec2_instance_id is defined
+      when: is_aws
 
 - name: Configure monitoring services (DataDog)
   hosts: all

--- a/ansible/setup.yml
+++ b/ansible/setup.yml
@@ -84,26 +84,19 @@
         update_cache: yes
         pkg:
         - build-essential
-        - python-yaml
-        - python-pip
+        - python3
+        - python3-yaml #epoch.fact
+        - python3-pip
+        - virtualenv
         - jq
         - unzip
       tags:
         - dev-tools
 
-    - name: Remove conflicting or obsolete packages
-      apt:
-        state: absent
-        pkg:
-        # Ansible paramico has dependency on newer cryptography version which is installed as pip module
-        # The OS package is older and once installed the pip version is not
-        - python-cryptography
-      tags:
-        - dev-tools
-
     - name: Install pip tools
       pip:
-        executable: pip2
+        virtualenv: /var/venv
+        virtualenv_python: python3
         name:
         - awscli
         - ansible

--- a/ansible/vars/epoch/dev1.yml
+++ b/ansible/vars/epoch/dev1.yml
@@ -29,3 +29,6 @@ epoch_config:
       # StatsD server and port
       host: 127.0.0.1
       port: 8125
+
+  fork_management:
+    network_id: "ae_dev1"

--- a/ansible/vars/epoch/fast_integration.yml
+++ b/ansible/vars/epoch/fast_integration.yml
@@ -43,3 +43,6 @@ epoch_config:
       # StatsD server and port
       host: 127.0.0.1
       port: 8125
+
+  fork_management:
+    network_id: "ae_fast_integration"

--- a/ansible/vars/epoch/main.yml
+++ b/ansible/vars/epoch/main.yml
@@ -1,14 +1,15 @@
-datadog_enabled: yes
 api_base_uri: http://{{ public_ipv4 }}:{{ epoch_config.http.external.port }}/v2
-genesis_accounts:
-  "ak_UAzhn9rAQg568v6Hwt3w2HPaQb9X9Nw6JbLmnv7trhmGmWGGp": 100000000001
 configure_peers: false
 seed_peers:
-  - "18.130.142.111"
+  - "35.177.192.219"
+  - "52.11.110.179"
+  - "52.220.198.72"
 
 epoch_config:
   peers:
-    - "aenode://pp_2SmwgNAp8zgHqNfCJEu5xLp7rN281ocnomAeEuJ5UPnkavroDs@18.130.142.111:3015"
+    - "aenode://pp_2KWhoNRdythXAmgCbM6QxFo95WM4XXGq2pjcbKitXFpUHnPQc3@35.177.192.219:3015"
+    - "aenode://pp_RKVZjm7UKPLGvyKWqVZN1pXN6CTCxfmYz2HkNL2xiAhLVd2ho@52.11.110.179:3015"
+    - "aenode://pp_2gPZjuPnJnTVEbrB9Qgv7f4MdhM4Jh6PD22mB2iBA1g7FRvHTk@52.220.198.72:3015"
 
   sync:
     port: 3015
@@ -28,15 +29,11 @@ epoch_config:
     db_path: "./db{{ db_version|mandatory }}"
 
   mining:
-    beneficiary: "ak_2VoAhMd7tVJrDYM5vPJwFRjueZyirDJumVJNeBWL9j1eNTHsRx"
-    cuckoo:
-      miner:
-        executable: mean29-avx2
-        extra_args: "-t {{ ansible_processor_vcpus }}"
-        edge_bits: 29
+    autostart: false
+    beneficiary: "ak_tjnw1KcmnwfqXvhtGa9GRjanbHM3t6PmEWEWtNMM3ouvNKRu5"
 
   logging:
-    level: debug
+    level: warning
 
   metrics:
       # StatsD server and port
@@ -44,4 +41,4 @@ epoch_config:
       port: 8125
 
   fork_management:
-    network_id: "ae_integration"
+    network_id: "ae_mainnet"

--- a/ansible/vars/epoch/uat.yml
+++ b/ansible/vars/epoch/uat.yml
@@ -39,3 +39,6 @@ epoch_config:
       # StatsD server and port
       host: 127.0.0.1
       port: 8125
+
+  fork_management:
+    network_id: "ae_uat"

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -49,8 +49,19 @@ fi
 
 export VAULT_TOKEN=$(vault write -field=token auth/aws/login pkcs7=$PKCS7 role=$vault_role nonce=$NONCE)
 
+# Run Ansible in virtual environment
+source /var/venv/bin/activate
+
 # Install ansible roles
 ansible-galaxy install -r requirements.yml
+
+# Dirty ugly hack to workaround missing python-apt in the virtualenv
+# It cannot be (?!) installed in the virtualenv
+# If --system-site-packages is used all the packages are copied and specifically python-cryptography
+# Distro python-cryptography is OLD and if copied to the virtualenv,
+# it prevents pip to installed newer package version for some reason,
+# but ansible (paramico) does not work with the OLD One
+cp -r /usr/lib/python3/dist-packages/apt* /var/venv/lib/python3.5/site-packages/
 
 # Create temporary inventory just because of the group_vars
 cat > /tmp/local_inventory << EOF
@@ -65,13 +76,25 @@ local
 
 EOF
 
+# While Ansible is run by Python 3 because of the virtual environment
+# the "remote" (which is in this case the same) host interpreter must also be set to python3
+# in this case it's the path in the virtual environment on the controller (same as the remote)
+# thus the which command usage.
+# It must be absolute because of the virtualenv, otherwise it will use the system Python 3
 ansible-playbook \
     -i /tmp/local_inventory \
+    -e ansible_python_interpreter=$(which python3) \
+    setup.yml
+
+ansible-playbook \
+    -i /tmp/local_inventory \
+    -e ansible_python_interpreter=$(which python3) \
     -e env=${env} \
     monitoring.yml
 
 ansible-playbook \
     -i /tmp/local_inventory \
+    -e ansible_python_interpreter=$(which python3) \
     --become-user epoch -b \
     -e package=${epoch_package} \
     -e env=${env} \

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -36,6 +36,77 @@ provider "aws" {
   profile                 = "aeternity"
 }
 
+module "aws_deploy-main-ap-southeast-1" {
+  source            = "modules/cloud/aws/deploy"
+  env               = "main"
+  bootstrap_version = "master"
+  vault_role        = "epoch-node"
+  vault_addr        = "${var.vault_addr}"
+
+  static_nodes = 1
+  spot_nodes   = 2
+
+  spot_price    = "0.15"
+  instance_type = "c5.xlarge"
+  ami_name      = "epoch-ubuntu-16.04-v1542910070"
+
+  epoch = {
+    package = "https://s3.eu-central-1.amazonaws.com/aeternity-epoch-builds/epoch-latest-ubuntu-x86_64.tar.gz"
+  }
+
+  providers = {
+    aws = "aws.ap-southeast-1"
+  }
+}
+
+module "aws_deploy-main-eu-west-2" {
+  source            = "modules/cloud/aws/deploy"
+  env               = "main"
+  bootstrap_version = "master"
+  vault_role        = "epoch-node"
+  vault_addr        = "${var.vault_addr}"
+
+  static_nodes = 1
+  spot_nodes   = 2
+
+  spot_price    = "0.15"
+  instance_type = "c5.xlarge"
+  ami_name      = "epoch-ubuntu-16.04-v1542910070"
+
+  epoch = {
+    package = "https://s3.eu-central-1.amazonaws.com/aeternity-epoch-builds/epoch-latest-ubuntu-x86_64.tar.gz"
+  }
+
+  providers = {
+    aws = "aws.eu-west-2"
+  }
+
+  depends_on = ["${module.aws_deploy-ap-southeast-1.static_node_ips}"]
+}
+
+module "aws_deploy-main-us-west-2" {
+  source            = "modules/cloud/aws/deploy"
+  env               = "main"
+  bootstrap_version = "master"
+  vault_role        = "epoch-node"
+  vault_addr        = "${var.vault_addr}"
+
+  static_nodes = 1
+  spot_nodes   = 2
+
+  spot_price    = "0.15"
+  instance_type = "c5.xlarge"
+  ami_name      = "epoch-ubuntu-16.04-v1542910070"
+
+  epoch = {
+    package = "https://s3.eu-central-1.amazonaws.com/aeternity-epoch-builds/epoch-latest-ubuntu-x86_64.tar.gz"
+  }
+
+  providers = {
+    aws = "aws.us-west-2"
+  }
+}
+
 module "aws_deploy-ap-southeast-1" {
   source            = "modules/cloud/aws/deploy"
   env               = "uat"


### PR DESCRIPTION
Playbooks tests are disabled temporary until we have better test environment - tracked as https://www.pivotaltracker.com/story/show/162164555
Right now it's very inconsistent and cannot find easy workaround. CI uses very old Ubuntu 14.04 where python packages does not match with 16/18.
