### PR TITLE
Add epoch systemd service file template to Ansible.  PT-153699467

### DIFF
--- a/ansible/deploy.yml
+++ b/ansible/deploy.yml
@@ -48,6 +48,7 @@
   max_fail_percentage: 25
 
   vars:
+    project_user: epoch
     project_root: "{{ ansible_env.HOME }}/node"
     packages_path: "{{ ansible_env.HOME }}"
     genesis_accounts_path: "{{ project_root }}/data/aecore/.genesis/accounts.json"
@@ -136,6 +137,13 @@
         when: remote_package.changed or local_package.changed
         notify: "start epoch daemon"
         tags: [package]
+
+      - name: Configure epoch systemd service
+        become_user: root
+        template:
+          src: epoch.service.j2
+          dest: /etc/systemd/system/epoch.service
+        notify: start epoch daemon
 
       - name: Plant ENV file
         copy:
@@ -284,15 +292,23 @@
         - "restart epoch daemon"
 
     - name: Stop epoch
-      command: "{{ project_root }}/bin/epoch stop"
-      when: epoch.stat.exists == True and ping.stdout == "pong"
+      become_user: root
+      systemd:
+        state: stopped
+        name: epoch
+        daemon_reload: yes
       tags: [daemon]
       listen:
         - "stop epoch daemon"
         - "restart epoch daemon"
 
     - name: Start epoch
-      command: "{{ project_root }}/bin/epoch start"
+      become_user: root
+      systemd:
+        state: started
+        name: epoch
+        daemon_reload: yes
+        enabled: yes
       tags: [daemon]
       listen:
         - "start epoch daemon"

--- a/ansible/deploy.yml
+++ b/ansible/deploy.yml
@@ -48,7 +48,6 @@
   max_fail_percentage: 25
 
   vars:
-    project_user: epoch
     project_root: "{{ ansible_env.HOME }}/node"
     packages_path: "{{ ansible_env.HOME }}"
     genesis_accounts_path: "{{ project_root }}/data/aecore/.genesis/accounts.json"
@@ -137,13 +136,6 @@
         when: remote_package.changed or local_package.changed
         notify: "start epoch daemon"
         tags: [package]
-
-      - name: Configure epoch systemd service
-        become_user: root
-        template:
-          src: epoch.service.j2
-          dest: /etc/systemd/system/epoch.service
-        notify: start epoch daemon
 
       - name: Plant ENV file
         copy:
@@ -292,23 +284,15 @@
         - "restart epoch daemon"
 
     - name: Stop epoch
-      become_user: root
-      systemd:
-        state: stopped
-        name: epoch
-        daemon_reload: yes
+      command: "{{ project_root }}/bin/epoch stop"
+      when: epoch.stat.exists == True and ping.stdout == "pong"
       tags: [daemon]
       listen:
         - "stop epoch daemon"
         - "restart epoch daemon"
 
     - name: Start epoch
-      become_user: root
-      systemd:
-        state: started
-        name: epoch
-        daemon_reload: yes
-        enabled: yes
+      command: "{{ project_root }}/bin/epoch start"
       tags: [daemon]
       listen:
         - "start epoch daemon"

--- a/ansible/templates/epoch.service.j2
+++ b/ansible/templates/epoch.service.j2
@@ -10,6 +10,7 @@ Group=users
 ExecStart={{ project_root }}/bin/epoch start
 ExecStop={{ project_root }}/bin/epoch stop
 Restart=on-failure
+# Systemd does not play well with user set limits with ulimit.
 LimitNOFILE=24576
 
 [Install]

--- a/ansible/templates/epoch.service.j2
+++ b/ansible/templates/epoch.service.j2
@@ -1,0 +1,16 @@
+[Unit]
+Description=Aeternity epoch
+Requires=network-online.target
+After=network-online.target
+
+[Service]
+Type=forking
+User={{ project_user }}
+Group=users
+ExecStart={{ project_root }}/bin/epoch start
+ExecStop={{ project_root }}/bin/epoch stop
+Restart=on-failure
+LimitNOFILE=24576
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Just adds systemd service file template in Ansible. It is not installed and used by playbooks. Cannot be used at the moment because of issues related to CI and systemd integration. 

https://www.pivotaltracker.com/n/projects/2152594/stories/153699467