### PR TITLE
Fix ansible deploy playbook indentation

### DIFF
--- a/ansible/deploy.yml
+++ b/ansible/deploy.yml
@@ -261,7 +261,7 @@
           tags: [datadog-event]
         - fail:
             msg: "Failed deploy"
-            when: true
+          when: true
 
   handlers:
     - name: Check epoch binary


### PR DESCRIPTION
This was causing fail datadog notification not being sent.

https://www.pivotaltracker.com/story/show/161812938