### PR TITLE
Integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -172,7 +172,9 @@ jobs:
 
   integration_tests:
     <<: *container_config
+    working_directory: /src
     steps:
+      - checkout
       - *setup_secrets
       - run:
           name: Integration Tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,7 +102,8 @@ jobs:
           name: Integration Tests
           # Secrets are auto-imported by the docker entry-point
           command: |
-            .circleci/docker-run.sh make integration-tests
+            source import-secrets.sh
+            make integration-tests
       - run:
           name: Setup ansible environment
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,15 +95,8 @@ jobs:
             .circleci/docker-run.sh make lint
       - run:
           name: Unit Tests
-          # Secrets are auto-imported by the docker entry-point
           command: |
             .circleci/docker-run.sh make unit-tests
-      - run:
-          name: Integration Tests
-          # Secrets are auto-imported by the docker entry-point
-          command: |
-            source import-secrets.sh
-            make integration-tests
       - run:
           name: Setup ansible environment
           command: |
@@ -177,6 +170,16 @@ jobs:
       - *check_seed_peers
       - *fail_notification
 
+  integration_tests:
+    <<: *container_config
+    steps:
+      - *setup_secrets
+      - run:
+          name: Integration Tests
+          command: |
+            make integration-tests
+      - *fail_notification
+
 workflows:
   version: 2
   check_deploy:
@@ -184,16 +187,23 @@ workflows:
       - build_check:
           requires: []
 
-      - setup_terraform:
+      - integration_tests:
           requires:
             - build_check
+          # filters:
+          #   branches:
+          #     only: master
+
+      - setup_terraform:
+          requires:
+            - integration_tests
           filters:
             branches:
               only: master
 
       - docker_push_latest:
           requires:
-            - build_check
+            - integration_tests
           filters:
             branches:
               only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -217,7 +217,7 @@ workflows:
             tags:
               only: /^v.*$/
 
-  daily_deploy:
+  daily_check_deploy:
     triggers:
       - schedule:
           cron: "0 12 * * *"
@@ -226,7 +226,12 @@ workflows:
               only:
                 - master
     jobs:
-      - setup_terraform
+      - integration_tests:
+          requires: []
+
+      - setup_terraform:
+          requires:
+            - integration_tests
 
   hourly_seeds_check:
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -192,9 +192,9 @@ workflows:
       - integration_tests:
           requires:
             - build_check
-          # filters:
-          #   branches:
-          #     only: master
+          filters:
+            branches:
+              only: master
 
       - setup_terraform:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,6 +94,16 @@ jobs:
           command: |
             .circleci/docker-run.sh make lint
       - run:
+          name: Unit Tests
+          # Secrets are auto-imported by the docker entry-point
+          command: |
+            .circleci/docker-run.sh make unit-tests
+      - run:
+          name: Integration Tests
+          # Secrets are auto-imported by the docker entry-point
+          command: |
+            .circleci/docker-run.sh make integration-tests
+      - run:
           name: Setup ansible environment
           command: |
             apk add sshpass

--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,5 @@ ansible/roles
 *.pyc
 .venv
 .terraform
+test/terraform/terraform.tfstate*
 ansible/inventory-list.json

--- a/Makefile
+++ b/Makefile
@@ -3,12 +3,6 @@ DEPLOY_DOWNTIME ?= 0
 BACKUP_SUFFIX ?= backup
 BACKUP_DIR ?= /tmp/mnesia_backups
 
-test-setup:
-	cd test/terraform && terraform init
-	cd test/terraform && terraform apply --auto-approve
-	cd ansible && ansible-playbook health-check.yml --limit=tag_env_tf_test
-	cd test/terraform && terraform destroy --auto-approve
-
 setup-terraform:
 	cd terraform && terraform init && terraform apply --auto-approve
 

--- a/ansible/health-check.yml
+++ b/ansible/health-check.yml
@@ -1,0 +1,18 @@
+---
+- name: Health check remote nodes
+  hosts: all
+  remote_user: epoch
+
+  vars:
+    env: unknown
+    db_version: 0
+
+  tasks:
+    - name: "Load a variable files for environment: {{ env }}"
+      include_vars: "{{ item }}"
+      with_first_found:
+        - "vars/epoch/{{ env }}.yml"
+        - "vars/epoch/default.yml"
+
+    - name: Run health checks
+      include_tasks: tasks/health_check.yml

--- a/ansible/inventory/aws.aws_ec2.yml
+++ b/ansible/inventory/aws.aws_ec2.yml
@@ -6,6 +6,7 @@ regions:
   - us-west-2
   - ap-southeast-1
   - eu-west-2
+  - us-east-1
   - us-east-2
 hostnames:
   - ip-address

--- a/ansible/tasks/health_check.yml
+++ b/ansible/tasks/health_check.yml
@@ -3,7 +3,7 @@
   wait_for:
     port: "{{ epoch_config.http.external.port }}"
     host: "{{ public_ipv4 }}"
-    timeout: 30
+    timeout: 180
   connection: local
 
 - name: API health check

--- a/test/terraform/test.tf
+++ b/test/terraform/test.tf
@@ -1,0 +1,32 @@
+variable "vault_addr" {
+  description = "Vault server URL address"
+}
+
+provider "aws" {
+  version = "1.24"
+  region  = "us-east-1"
+  alias   = "us-east-1"
+}
+
+module "aws_deploy-test" {
+  source            = "../../terraform/modules/cloud/aws/deploy"
+  env               = "tf_test"
+  bootstrap_version = "master"
+  vault_role        = "epoch-node"
+  vault_addr        = "${var.vault_addr}"
+
+  static_nodes = 1
+  spot_nodes   = 1
+
+  spot_price    = "0.05"
+  instance_type = "t3.medium"
+  ami_name      = "epoch-ubuntu-16.04-*"
+
+  epoch = {
+    package = "https://s3.eu-central-1.amazonaws.com/aeternity-epoch-builds/epoch-latest-ubuntu-x86_64.tar.gz"
+  }
+
+  providers = {
+    aws = "aws.us-east-1"
+  }
+}


### PR DESCRIPTION
Run integration tests on master merges and daily:
- spawn a simple fleet
- health check the nodes
- destroy the fleet

https://www.pivotaltracker.com/story/show/162310158
The original request in PT was for "nightly" runs only, but I think it's better to check on master merges as well. Also it will be better to run it "daily" together (before) with the "daily deploy" task.

Example job run: https://circleci.com/gh/aeternity/infrastructure/7112