### PR TITLE
Change aeternity nodes role name

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -145,7 +145,7 @@ module "aws_deploy-ap-southeast-1" {
   env               = "uat"
   color             = "blue"
   bootstrap_version = "v1.7.0"
-  vault_role        = "epoch-node"
+  vault_role        = "ae-node"
   vault_addr        = "${var.vault_addr}"
 
   static_nodes = 1
@@ -169,7 +169,7 @@ module "aws_deploy-eu-central-1" {
   env               = "uat"
   color             = "blue"
   bootstrap_version = "v1.7.0"
-  vault_role        = "epoch-node"
+  vault_role        = "ae-node"
   vault_addr        = "${var.vault_addr}"
 
   static_nodes = 1
@@ -195,7 +195,7 @@ module "aws_deploy-us-west-2" {
   env               = "uat"
   color             = "green"
   bootstrap_version = "v1.7.0"
-  vault_role        = "epoch-node"
+  vault_role        = "ae-node"
   vault_addr        = "${var.vault_addr}"
 
   static_nodes = 1
@@ -219,7 +219,7 @@ module "aws_deploy-uat-eu-west-2" {
   env               = "uat"
   color             = "green"
   bootstrap_version = "v1.7.0"
-  vault_role        = "epoch-node"
+  vault_role        = "ae-node"
   vault_addr        = "${var.vault_addr}"
 
   static_nodes = 1
@@ -244,7 +244,7 @@ module "aws_deploy-dev1-eu-west-2" {
   source            = "modules/cloud/aws/deploy"
   env               = "dev1"
   bootstrap_version = "v1.7.0"
-  vault_role        = "epoch-node"
+  vault_role        = "ae-node"
   vault_addr        = "${var.vault_addr}"
 
   spot_nodes    = 10
@@ -265,7 +265,7 @@ module "aws_deploy-dev2-eu-west-2" {
   source            = "modules/cloud/aws/deploy"
   env               = "dev2"
   bootstrap_version = "master"
-  vault_role        = "epoch-node"
+  vault_role        = "ae-node"
   vault_addr        = "${var.vault_addr}"
 
   spot_nodes    = 2
@@ -286,7 +286,7 @@ module "aws_deploy-integration-eu-west-2" {
   source            = "modules/cloud/aws/deploy"
   env               = "integration"
   bootstrap_version = "v1.7.0"
-  vault_role        = "epoch-node"
+  vault_role        = "ae-node"
   vault_addr        = "${var.vault_addr}"
 
   static_nodes  = 1

--- a/terraform/modules/cloud/aws/deploy/fleet/main.tf
+++ b/terraform/modules/cloud/aws/deploy/fleet/main.tf
@@ -16,7 +16,7 @@ resource "aws_instance" "static_node" {
   count                = "${var.static_nodes}"
   ami                  = "${data.aws_ami.ami.id}"
   instance_type        = "${var.instance_type}"
-  iam_instance_profile = "epoch-node"
+  iam_instance_profile = "ae-node"
 
   root_block_device {
     volume_type = "gp2"
@@ -52,7 +52,7 @@ data "template_file" "user_data" {
 
 resource "aws_launch_configuration" "spot" {
   name_prefix          = "ae-${var.env}-spot-nodes_"
-  iam_instance_profile = "epoch-node"
+  iam_instance_profile = "ae-node"
   image_id             = "${data.aws_ami.ami.id}"
   instance_type        = "${var.instance_type}"
   spot_price           = "${var.spot_price}"


### PR DESCRIPTION
In scope of https://www.pivotaltracker.com/story/show/163323269

While 03e8897 will not cause instance re-spawn, 1cac4e4 will do because it changes the bootstrap user data, thus the main nodes are not changed for now.