### PR TITLE
Add cleanup step for failed integration test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -180,6 +180,11 @@ jobs:
           name: Integration Tests
           command: |
             make integration-tests
+      - run:
+          name: Integration env cleanup
+          command: |
+            make integration-tests-cleanup
+          when: on_fail
       - *fail_notification
 
 workflows:

--- a/Makefile
+++ b/Makefile
@@ -87,12 +87,16 @@ ssh: ssh-epoch
 unit-tests:
 	cd terraform && terraform init && terraform plan
 
-integration-tests:
+integration-tests-run:
 	cd test/terraform && terraform init
 	cd test/terraform && terraform apply --auto-approve
 	# TODO this is actually a smoke test that can be migrated to "goss"
 	cd ansible && ansible-playbook health-check.yml --limit=tag_env_tf_test
+
+integration-tests-cleanup:
 	cd test/terraform && terraform destroy --auto-approve
+
+integration-tests: integration-tests-run integration-tests-cleanup
 
 lint:
 	ansible-lint ansible/*.yml --exclude ~/.ansible/roles


### PR DESCRIPTION
Split integration-tests target to run and cleanup so cleanup could
be called separately by CircleCI on failure