### PR TITLE
Add seed node configuration to unstable environment

### DIFF
--- a/ansible/vars/aeternity/unstable.yml
+++ b/ansible/vars/aeternity/unstable.yml
@@ -4,10 +4,7 @@ configure_peers: false
 
 node_config:
   peers:
-    - "aenode://pp_QU9CvhAQH56a2kA15tCnWPRJ2srMJW8ZmfbbFTAy7eG4o16Bf@52.10.46.160:3015"
-    - "aenode://pp_2vhFb3HtHd1S7ynbpbFnEdph1tnDXFSfu4NGtq46S2eM5HCdbC@18.195.109.60:3015"
-    - "aenode://pp_27xmgQ4N1E3QwHyoutLtZsHW5DSW4zneQJ3CxT5JbUejxtFuAu@13.250.162.250:3015"
-    - "aenode://pp_nt5N7fwae3DW8Mqk4kxkGAnbykRDpEZq9dzzianiMMPo4fJV7@18.130.148.7:3015"
+    - "aenode://pp_2oaiqmJnrAVzVkmbgzr4hgFYuqfqtppBVjjh1qMsJhJFvDZqby@3.8.38.115:3015"
   sync:
     port: 3015
 


### PR DESCRIPTION
As this is not backward compatible and the p2p protocol reject such nodes, it needs it's own seed peers.