### PR TITLE
change ec2 node size

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -83,7 +83,7 @@ module "aws_deploy-main-eu-west-2" {
   spot_nodes   = 0
 
   spot_price       = "0.15"
-  instance_type    = "c5.xlarge"
+  instance_type    = "t3.small"
   ami_name         = "epoch-ubuntu-16.04-v1542910070"
   root_volume_size = 16
 
@@ -159,7 +159,7 @@ module "aws_deploy-main-us-east-2" {
   spot_nodes   = 0
 
   spot_price       = "0.15"
-  instance_type    = "c5.xlarge"
+  instance_type    = "t3.small"
   ami_name         = "epoch-ubuntu-16.04-v1542910070"
   root_volume_size = 16
 
@@ -184,7 +184,7 @@ module "aws_deploy-ap-southeast-1" {
   spot_nodes   = 14
 
   spot_price    = "0.125"
-  instance_type = "t3.small"
+  instance_type = "m4.large"
   ami_name      = "epoch-ubuntu-16.04-v1542985640"
 
   aeternity = {
@@ -258,7 +258,7 @@ module "aws_deploy-uat-eu-west-2" {
   spot_nodes   = 9
 
   spot_price    = "0.125"
-  instance_type = "t3.small"
+  instance_type = "m4.large"
   ami_name      = "epoch-ubuntu-16.04-v1542985640"
 
   aeternity = {
@@ -307,7 +307,7 @@ module "aws_deploy-dev1-eu-west-2" {
 
   spot_nodes    = 10
   spot_price    = "0.125"
-  instance_type = "t3.small"
+  instance_type = "m4.large"
   ami_name      = "epoch-ubuntu-16.04-v1542985640"
 
   aeternity = {
@@ -372,7 +372,7 @@ module "aws_deploy-next-eu-west-2" {
   static_nodes  = 1
   spot_nodes    = 2
   spot_price    = "0.125"
-  instance_type = "t3.small"
+  instance_type = "m4.large"
   ami_name      = "aeternity-ubuntu-16.04-v1548684655"
 
   aeternity = {
@@ -394,7 +394,7 @@ module "aws_deploy-unstable-eu-west-2" {
   static_nodes  = 1
   spot_nodes    = 2
   spot_price    = "0.125"
-  instance_type = "t3.small"
+  instance_type = "m4.large"
   ami_name      = "aeternity-ubuntu-16.04-v1548684655"
 
   aeternity = {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -59,7 +59,7 @@ module "aws_deploy-main-ap-southeast-1" {
   spot_nodes   = 0
 
   spot_price       = "0.15"
-  instance_type    = "c5.xlarge"
+  instance_type    = "t3.small"
   ami_name         = "epoch-ubuntu-16.04-v1542910070"
   root_volume_size = 16
 
@@ -109,7 +109,7 @@ module "aws_deploy-main-eu-north-1" {
   spot_nodes   = 0
 
   spot_price       = "0.15"
-  instance_type    = "c5.xlarge"
+  instance_type    = "t3.small"
   ami_name         = "aeternity-ubuntu-16.04-v1548669657"
   root_volume_size = 16
 
@@ -135,7 +135,7 @@ module "aws_deploy-main-us-west-2" {
   spot_nodes   = 0
 
   spot_price       = "0.15"
-  instance_type    = "c5.xlarge"
+  instance_type    = "t3.small"
   ami_name         = "epoch-ubuntu-16.04-v1542910070"
   root_volume_size = 16
 
@@ -184,7 +184,7 @@ module "aws_deploy-ap-southeast-1" {
   spot_nodes   = 14
 
   spot_price    = "0.125"
-  instance_type = "m4.large"
+  instance_type = "t3.small"
   ami_name      = "epoch-ubuntu-16.04-v1542985640"
 
   aeternity = {
@@ -258,7 +258,7 @@ module "aws_deploy-uat-eu-west-2" {
   spot_nodes   = 9
 
   spot_price    = "0.125"
-  instance_type = "m4.large"
+  instance_type = "t3.small"
   ami_name      = "epoch-ubuntu-16.04-v1542985640"
 
   aeternity = {
@@ -307,7 +307,7 @@ module "aws_deploy-dev1-eu-west-2" {
 
   spot_nodes    = 10
   spot_price    = "0.125"
-  instance_type = "m4.large"
+  instance_type = "t3.small"
   ami_name      = "epoch-ubuntu-16.04-v1542985640"
 
   aeternity = {
@@ -372,7 +372,7 @@ module "aws_deploy-next-eu-west-2" {
   static_nodes  = 1
   spot_nodes    = 2
   spot_price    = "0.125"
-  instance_type = "m4.large"
+  instance_type = "t3.small"
   ami_name      = "aeternity-ubuntu-16.04-v1548684655"
 
   aeternity = {
@@ -394,7 +394,7 @@ module "aws_deploy-unstable-eu-west-2" {
   static_nodes  = 1
   spot_nodes    = 2
   spot_price    = "0.125"
-  instance_type = "m4.large"
+  instance_type = "t3.small"
   ami_name      = "aeternity-ubuntu-16.04-v1548684655"
 
   aeternity = {


### PR DESCRIPTION
Because of node size do not give us big difference with synch time, decreasing to smallest / cheapest instance with 2gb of mem.

![screenshot 2019-02-05 12 55 22](https://user-images.githubusercontent.com/533787/52272147-219e9000-2946-11e9-9f2f-9ece3993bdc7.png)

screen show sync time from 20400 -> 33200 in seconds(3rd row) / minutes (4th row)

PT: https://www.pivotaltracker.com/story/show/163018427