### PR TITLE
Improve error handling on nonce 163696101

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -44,7 +44,17 @@ if [ -f "/root/.vault_nonce" ] ; then
     export NONCE=$(cat /root/.vault_nonce)
 else
     export NONCE=$(vault write auth/aws/login pkcs7=$PKCS7 role=$vault_role | grep token_meta_nonce | awk '{print $2}')
+    if [ -z "$NONCE" ]; then
+        echo "NONCE is empty"
+        exit 1
+    fi
+
     echo $NONCE > /root/.vault_nonce
+
+    if [ $? -nq 0 ]; then
+        echo "not able to save NONCE"
+        exit 1
+    fi
     chmod 0600 /root/.vault_nonce
 fi
 

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -41,15 +41,15 @@ PKCS7=$(curl -s http://169.254.169.254/latest/dynamic/instance-identity/pkcs7 | 
 
 export VAULT_ADDR=$vault_addr
 if [ -f "/root/.vault_nonce" ] ; then
-    export NONCEa=$(cat /root/.vault_nonce)
+    export NONCE=$(cat /root/.vault_nonce)
 else
-    export NONCEa=$(vault write auth/aws/login pkcs7=$PKCS7 role=$vault_role | grep token_meta_nonce | awk '{print $2}')
+    export NONCE=$(vault write auth/aws/login pkcs7=$PKCS7 role=$vault_role | grep token_meta_nonce | awk '{print $2}')
     if [ -z "$NONCE" ]; then
         echo "NONCE is empty"
         exit 1
     fi
 
-    echo $NONCE > /root/.vault_nonce
+    echo $NONCE > /rooasdt/.vault_nonce
 
     if [ $? -nq 0 ]; then
         echo "not able to save NONCE"

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -41,9 +41,9 @@ PKCS7=$(curl -s http://169.254.169.254/latest/dynamic/instance-identity/pkcs7 | 
 
 export VAULT_ADDR=$vault_addr
 if [ -f "/root/.vault_nonce" ] ; then
-    export NONCE=$(cat /root/.vault_nonce)
+    export NONCEa=$(cat /root/.vault_nonce)
 else
-    export NONCE=$(vault write auth/aws/login pkcs7=$PKCS7 role=$vault_role | grep token_meta_nonce | awk '{print $2}')
+    export NONCEa=$(vault write auth/aws/login pkcs7=$PKCS7 role=$vault_role | grep token_meta_nonce | awk '{print $2}')
     if [ -z "$NONCE" ]; then
         echo "NONCE is empty"
         exit 1

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -51,10 +51,6 @@ else
 
     echo $NONCE > /root/.vault_nonce
 
-    if [ $? -nq 0 ]; then
-        echo "not able to save NONCE"
-        exit 1
-    fi
     chmod 0600 /root/.vault_nonce
 fi
 

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -49,7 +49,7 @@ else
         exit 1
     fi
 
-    echo $NONCE > /rooasdt/.vault_nonce
+    echo $NONCE > /root/.vault_nonce
 
     if [ $? -nq 0 ]; then
         echo "not able to save NONCE"


### PR DESCRIPTION
PT: https://www.pivotaltracker.com/story/show/163696101

Tested for empty nonce:

```
master@ip-10-0-1-135:~$ cat /tmp/user-data.log
Cloning into '/infrastructure'...
WARNING! The following warnings were returned from Vault:

  * TTL of "768h0m0s" exceeded the effective max_ttl of "30m0s"; TTL value is
  capped accordingly

NONCE is empty
master@ip-10-0-1-135:~$
```
do not have idea how to test it on saving issue, but this `if` should work