### PR TITLE
Add unique key to integration tests PT-163695463

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -179,11 +179,11 @@ jobs:
       - run:
           name: Integration Tests
           command: |
-            make integration-tests TF_VAR_current_branch="_${CIRCLE_SHA1}"
+            make integration-tests TF_VAR_env_name="tf_test_${CIRCLE_SHA1}"
       - run:
           name: Integration env cleanup
           command: |
-            make integration-tests-cleanup TF_VAR_current_branch="_${CIRCLE_SHA1}"
+            make integration-tests-cleanup TF_VAR_env_name="tf_test_${CIRCLE_SHA1}"
           when: on_fail
       - *fail_notification
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -179,11 +179,11 @@ jobs:
       - run:
           name: Integration Tests
           command: |
-            make integration-tests
+            make integration-tests TF_VAR_current_branch="_${CIRCLE_SHA1}"
       - run:
           name: Integration env cleanup
           command: |
-            make integration-tests-cleanup
+            make integration-tests-cleanup TF_VAR_current_branch="_${CIRCLE_SHA1}"
           when: on_fail
       - *fail_notification
 

--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ integration-tests-run:
 	cd test/terraform && terraform init
 	cd test/terraform && terraform apply --auto-approve
 	# TODO this is actually a smoke test that can be migrated to "goss"
-	cd ansible && ansible-playbook health-check.yml --limit=tag_env_tf_test
+	cd ansible && ansible-playbook health-check.yml --limit=tag_env_tf_test$(TF_VAR_current_branch)
 
 integration-tests-cleanup:
 	cd test/terraform && terraform destroy --auto-approve

--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ integration-tests-run:
 	cd test/terraform && terraform init
 	cd test/terraform && terraform apply --auto-approve
 	# TODO this is actually a smoke test that can be migrated to "goss"
-	cd ansible && ansible-playbook health-check.yml --limit=tag_env_tf_test$(TF_VAR_current_branch)
+	cd ansible && ansible-playbook health-check.yml --limit=tag_env_$(TF_VAR_env_name)
 
 integration-tests-cleanup:
 	cd test/terraform && terraform destroy --auto-approve

--- a/README.md
+++ b/README.md
@@ -320,7 +320,11 @@ All of the above can be run with single `make` wrapper:
 make integration-tests
 ```
 
-*Note that this environment is also used and run automatically each day by the CI server, it also can be run by other users as well. It's not designed to be multi-user yet, so a bit of coordination should be made to prevent collisions*
+*Note these test are run automatically each day by the CI server, and can be run by other users as well. To prevent collisions you can specify unique environment name instead the default "tf_test" (do not use special symbols other than "_", otherwise tests will not pass):*
+
+```bash
+make integration-tests TF_VAR_env_name=tf_test_my_test_env
+```
 
 ### CircleCI configuration
 

--- a/test/terraform/test.tf
+++ b/test/terraform/test.tf
@@ -2,8 +2,8 @@ variable "vault_addr" {
   description = "Vault server URL address"
 }
 
-variable "current_branch" {
-  default = ""
+variable "env_name" {
+  default = "tf_test"
 }
 
 provider "aws" {
@@ -14,7 +14,7 @@ provider "aws" {
 
 module "aws_deploy-test" {
   source            = "../../terraform/modules/cloud/aws/deploy"
-  env               = "tf_test${var.current_branch}"
+  env               = "${var.env_name}"
   bootstrap_version = "master"
   vault_role        = "ae-node"
   vault_addr        = "${var.vault_addr}"

--- a/test/terraform/test.tf
+++ b/test/terraform/test.tf
@@ -2,6 +2,10 @@ variable "vault_addr" {
   description = "Vault server URL address"
 }
 
+variable "current_branch" {
+  default = ""
+}
+
 provider "aws" {
   version = "1.55"
   region  = "ap-southeast-2"
@@ -10,7 +14,7 @@ provider "aws" {
 
 module "aws_deploy-test" {
   source            = "../../terraform/modules/cloud/aws/deploy"
-  env               = "tf_test"
+  env               = "tf_test${var.current_branch}"
   bootstrap_version = "master"
   vault_role        = "ae-node"
   vault_addr        = "${var.vault_addr}"


### PR DESCRIPTION
Related to https://www.pivotaltracker.com/story/show/163695463
add circle_sha1 to tf_test to make unique env name
successfully ran two integration tests simultaneously