### PR TITLE
Disable daily terraform setup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -234,9 +234,9 @@ workflows:
       - integration_tests:
           requires: []
 
-      - setup_terraform:
-          requires:
-            - integration_tests
+      # - setup_terraform:
+      #     requires:
+      #       - integration_tests
 
   hourly_seeds_check:
     triggers:


### PR DESCRIPTION
We have to disable automatic runs for a while, because current terraform state is not in sync with master.