### PR TITLE
decrease donwtime with node rotation

### DIFF
--- a/terraform/modules/cloud/aws/deploy/fleet/ip.tf
+++ b/terraform/modules/cloud/aws/deploy/fleet/ip.tf
@@ -6,4 +6,8 @@ resource "aws_eip_association" "ip_associate" {
   count         = "${var.static_nodes}"
   instance_id   = "${aws_instance.static_node.*.id[count.index]}"
   allocation_id = "${aws_eip.ip.*.id[count.index]}"
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }


### PR DESCRIPTION
pt: https://www.pivotaltracker.com/story/show/163826822

So for static nodes:

1. tf will create boot new node
2. tf will swap IP address to new node. No health check it just wait for instance boot, and swap ip.

* if terrafrom will detect that changes do not require instance termination, it will stop / start node like just for changing instance size.
For spot nodes:

1. tf will create new ASG run new nodes
2. tf will terminate old nodes