### PR TITLE
Group hosts by region inventory list

### DIFF
--- a/ansible/dump_inventory.py
+++ b/ansible/dump_inventory.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 """
-Simple script that takes a ansible-inventory JSON output (stdin) 
+Simple script that takes a ansible-inventory JSON output (stdin)
 and dumps inventory markdown grouped by environment.
 
 Examples
@@ -9,7 +9,7 @@ Examples
 ansible-inventory --list | ./dump_inventory.py
 
 """
- 
+
 import sys, json, re
 
 env_group_prefix = 'tag_env_'
@@ -22,13 +22,13 @@ env_groups = [g for g in filtered_groups if g.startswith(env_group_prefix)]
 # source https://stackoverflow.com/a/16090640/3967231
 def natural_sort_key(s, _nsre=re.compile('([0-9]+)')):
     return [int(text) if text.isdigit() else text.lower()
-            for text in re.split(_nsre, s)]   
+            for text in re.split(_nsre, s)]
 
 def print_host(host):
         host_ip = host
         if 'ansible_host' in hostvars[host]:
             host_ip = hostvars[host]['ansible_host']
-        print("  - %s (%s) [status](http://%s:3013/v2/status) [top](http://%s:3013/v2/blocks/top)" % (host, host_ip, host_ip, host_ip))
+        print("    - %s (%s) [status](http://%s:3013/v2/status) [top](http://%s:3013/v2/blocks/top)" % (host, host_ip, host_ip, host_ip))
 
 for group_name in env_groups:
     print("#### %s\n" % group_name[len(env_group_prefix):])
@@ -43,10 +43,26 @@ for group_name in env_groups:
             peers.append(host)
     if seeds:
         print('**seeds:**')
+        regions = []
         for seed in seeds:
-            print_host(seed)
+            seed_region = hostvars[seed]['placement']['region']
+            if seed_region not in regions:
+                regions.append(seed_region)
+        for region in regions:
+            print("  *%s*:" % region )
+            for seed in seeds:
+                if hostvars[seed]['placement']['region'] == region:
+                    print_host(seed)
     if peers:
         print('**peers:**')
+        regions = []
         for peer in peers:
-            print_host(peer)
+            peer_region = hostvars[peer]['placement']['region']
+            if peer_region not in regions:
+                regions.append(peer_region)
+        for region in regions:
+            print("  *%s*:" % region )
+            for peer in peers:
+                if hostvars[peer]['placement']['region'] == region:
+                    print_host(peer)
     print("\n")

--- a/ansible/dump_inventory.py
+++ b/ansible/dump_inventory.py
@@ -30,6 +30,14 @@ def print_host(host):
             host_ip = hostvars[host]['ansible_host']
         print("    - %s (%s) [status](http://%s:3013/v2/status) [top](http://%s:3013/v2/blocks/top)" % (host, host_ip, host_ip, host_ip))
 
+def set_hosts_regions(hosts):
+    regions = []
+    for host in hosts:
+        host_region = hostvars[host]['placement']['region']
+        if host_region not in regions:
+            regions.append(host_region)
+    return regions
+
 for group_name in env_groups:
     print("#### %s\n" % group_name[len(env_group_prefix):])
     hosts = data[group_name]['hosts'].sort(key=natural_sort_key)
@@ -43,24 +51,14 @@ for group_name in env_groups:
             peers.append(host)
     if seeds:
         print('**seeds:**')
-        regions = []
-        for seed in seeds:
-            seed_region = hostvars[seed]['placement']['region']
-            if seed_region not in regions:
-                regions.append(seed_region)
-        for region in regions:
+        for region in set_hosts_regions(seeds):
             print("  *%s*:" % region )
             for seed in seeds:
                 if hostvars[seed]['placement']['region'] == region:
                     print_host(seed)
     if peers:
         print('**peers:**')
-        regions = []
-        for peer in peers:
-            peer_region = hostvars[peer]['placement']['region']
-            if peer_region not in regions:
-                regions.append(peer_region)
-        for region in regions:
+        for region in set_hosts_regions(peers):
             print("  *%s*:" % region )
             for peer in peers:
                 if hostvars[peer]['placement']['region'] == region:


### PR DESCRIPTION
Output of `make list-inventory` is like that:

#### integration

**seeds:**
  *eu-west-2*:
    - 35.177.40.45 (35.177.40.45) [status](http://35.177.40.45:3013/v2/status) [top](http://35.177.40.45:3013/v2/blocks/top)
**peers:**
  *eu-west-2*:
    - 3.8.147.205 (3.8.147.205) [status](http://3.8.147.205:3013/v2/status) [top](http://3.8.147.205:3013/v2/blocks/top)
    - 18.130.239.67 (18.130.239.67) [status](http://18.130.239.67:3013/v2/status) [top](http://18.130.239.67:3013/v2/blocks/top)


#### main

**seeds:**
  *ap-southeast-1*:
    - 3.0.12.164 (3.0.12.164) [status](http://3.0.12.164:3013/v2/status) [top](http://3.0.12.164:3013/v2/blocks/top)
    - 3.0.86.27 (3.0.86.27) [status](http://3.0.86.27:3013/v2/status) [top](http://3.0.86.27:3013/v2/blocks/top)