### PR TITLE
Enable goss service to start on reboot pt 165443453

### DIFF
--- a/ansible/monitoring.yml
+++ b/ansible/monitoring.yml
@@ -114,6 +114,15 @@
       tags:
         - goss-install
 
+    - name: Enable goss systemd service start on boot
+      systemd:
+        name: goss
+        enable: yes
+      notify: reload systemd
+      when: systemd_run_dir.stat.exists and systemd_run_dir.stat.isdir
+      tags:
+        - goss-install
+
     - name: Copy init.d goss config
       copy:
         src: files/goss/goss.conf

--- a/ansible/monitoring.yml
+++ b/ansible/monitoring.yml
@@ -117,7 +117,7 @@
     - name: Enable goss systemd service start on boot
       systemd:
         name: goss
-        enable: yes
+        enabled: yes
       notify: reload systemd
       when: systemd_run_dir.stat.exists and systemd_run_dir.stat.isdir
       tags:

--- a/ansible/monitoring.yml
+++ b/ansible/monitoring.yml
@@ -108,7 +108,7 @@
       copy:
         src: files/goss/goss.service
         dest: "/etc/systemd/system"
-        mode: 0750
+        mode: 0640
       notify: reload systemd
       when: systemd_run_dir.stat.exists and systemd_run_dir.stat.isdir
       tags:


### PR DESCRIPTION
In scope of [PT-165443453](https://www.pivotaltracker.com/story/show/165443453)
```
TASK [Enable goss systemd service start on boot] *******************************
Thursday 25 April 2019  12:06:43 +0000 (0:00:00.436)       0:00:05.495 ******** 
changed: [localhost]
```
after reboot:
```
TASK [Enable goss systemd service start on boot] *******************************
Thursday 25 April 2019  12:09:07 +0000 (0:00:00.436)       0:00:05.507 ******** 
ok: [localhost]
```
---
```
systemctl status goss
● goss.service - Goss
   Loaded: loaded (/etc/systemd/system/goss.service; enabled; vendor preset: enabled)
   Active: active (running) since Thu 2019-04-25 12:08:28 UTC; 3min 52s ago
 Main PID: 1124 (goss)
    Tasks: 7
   Memory: 12.6M
      CPU: 130ms
   CGroup: /system.slice/goss.service
           └─1124 /usr/bin/goss -g /etc/goss/health.yml serve &
```