### PR TITLE
Disable facts gathering in health check playbook

### DIFF
--- a/ansible/health-check.yml
+++ b/ansible/health-check.yml
@@ -2,6 +2,7 @@
 - name: Health check remote nodes
   hosts: all
   remote_user: aeternity
+  gather_facts: false
 
   vars:
     env: unknown


### PR DESCRIPTION
Otherwise the SSH is not ready at the time the checks are run, thus facts gathering fails. As it's not actually used, disabling it should solve the intermittent failures