### PR TITLE
Dont' require configuration file to exist in addional storage playbook

### DIFF
--- a/ansible/tasks/additional_storage.yml
+++ b/ansible/tasks/additional_storage.yml
@@ -15,7 +15,9 @@
 - name: "Load a variable files for environment: {{ env }}"
   include_vars: "{{ item }}"
   with_first_found:
-    - "vars/aeternity/{{ env }}.yml"
+    - files:
+        - "vars/aeternity/{{ env }}.yml"
+      skip: true
 
 - name: "Wait for /dev/nvme1n1 to become present"
   wait_for:


### PR DESCRIPTION
Should fix https://www.pivotaltracker.com/story/show/166438273

This set of tasks depends on `additional_storage` to execute. Without env configuration file it should not run.