### PR TITLE
Deploy Lima in 'next' env

### DIFF
--- a/ansible/vars/aeternity/next.yml
+++ b/ansible/vars/aeternity/next.yml
@@ -29,6 +29,7 @@ node_config:
       "1": 0
       "2": 1
       "3": 2
+      "4": 3
 
   mining:
     autostart: true


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/166267638

Note:
It appears that latest datadog (0.29.0) has a bug on install which makes CI fails
https://github.com/DataDog/datadogpy/issues/390

So I added version constraints to all tools