### PR TITLE
Fix missing db_path var for api_uat env

### DIFF
--- a/ansible/deploy.yml
+++ b/ansible/deploy.yml
@@ -131,7 +131,10 @@
       - name: Fail on missing 'node_config.chain.db_path' variable
         fail:
           msg: 'Chain persistence is enabled, but "node_config.chain.db_path" is not defined'
-        when: node_config.chain.persist is defined and node_config.chain.persist and node_config.chain.db_path is not defined
+        when:
+          - node_config.chain.persist is defined
+          - node_config.chain.persist
+          - node_config.chain.db_path is not defined
         tags: [config]
 
       - name: "Make sure chain path exists"

--- a/ansible/deploy.yml
+++ b/ansible/deploy.yml
@@ -128,6 +128,12 @@
         notify: "restart aeternity daemon"
         tags: [package]
 
+      - name: Fail on missing 'node_config.chain.db_path' variable
+        fail:
+          msg: 'Chain persistence is enabled, but "node_config.chain.db_path" is not defined'
+        when: node_config.chain.persist is defined and node_config.chain.persist and node_config.chain.db_path is not defined
+        tags: [config]
+
       - name: "Make sure chain path exists"
         file:
           path: "{{ project_root }}/{{ node_config.chain.db_path }}"

--- a/ansible/vars/aeternity/api_uat.yml
+++ b/ansible/vars/aeternity/api_uat.yml
@@ -27,6 +27,7 @@ node_config:
 
   chain:
     persist: true
+    db_path: "./db{{ db_version|mandatory }}"
     protocol_beneficiaries: ["ak_2A3PZPfMC2X7ZVy4qGXz2xh2Lbh79Q4UvZ5fdH7QVFocEgcKzU:109"]
 
   logging:

--- a/ansible/vars/aeternity/api_uat.yml
+++ b/ansible/vars/aeternity/api_uat.yml
@@ -11,6 +11,9 @@ node_config:
     - aenode://pp_2vhFb3HtHd1S7ynbpbFnEdph1tnDXFSfu4NGtq46S2eM5HCdbC@18.195.109.60:3015
     - aenode://pp_27xmgQ4N1E3QwHyoutLtZsHW5DSW4zneQJ3CxT5JbUejxtFuAu@13.250.162.250:3015
     - aenode://pp_DMLqy7Zuhoxe2FzpydyQTgwCJ52wouzxtHWsPGo51XDcxc5c8@13.53.161.215:3015
+  sync:
+    port: 3015
+    max_gossip: 100
 
   http:
     external:
@@ -25,9 +28,13 @@ node_config:
       port: 3014
       listen_address: 0.0.0.0
 
+  keys:
+    dir: keys
+    peer_password: secret
+
   chain:
     persist: true
-    db_path: "./db{{ db_version|mandatory }}"
+    db_path: "/data/db{{ db_version|mandatory }}"
     protocol_beneficiaries: ["ak_2A3PZPfMC2X7ZVy4qGXz2xh2Lbh79Q4UvZ5fdH7QVFocEgcKzU:109"]
 
   logging:

--- a/ansible/vars/aeternity/api_uat.yml
+++ b/ansible/vars/aeternity/api_uat.yml
@@ -11,9 +11,6 @@ node_config:
     - aenode://pp_2vhFb3HtHd1S7ynbpbFnEdph1tnDXFSfu4NGtq46S2eM5HCdbC@18.195.109.60:3015
     - aenode://pp_27xmgQ4N1E3QwHyoutLtZsHW5DSW4zneQJ3CxT5JbUejxtFuAu@13.250.162.250:3015
     - aenode://pp_DMLqy7Zuhoxe2FzpydyQTgwCJ52wouzxtHWsPGo51XDcxc5c8@13.53.161.215:3015
-  sync:
-    port: 3015
-    max_gossip: 100
 
   http:
     external:


### PR DESCRIPTION
Ad missing db_path var in `api_uat.yaml` env
and Check for missing `db_path` var if `persist: true` to prevent further misconfigurations

Node is deployed but ansible fails to create the db directory (as the var is undefined)

in scope of https://www.pivotaltracker.com/story/show/164978300