### PR TITLE
Restore env for api_uat

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -135,6 +135,10 @@ if [ "$env" = "api_main" ] ; then
     RESTORE_ENV=main
 fi
 
+if [ "$env" = "api_uat" ] ; then
+    RESTORE_ENV=uat
+fi
+
 if [ "$RESTORE_DATABASE" = true ] ; then
     if [ "$RESTORE_ENV" = "main" ] || [ "$RESTORE_ENV" == "uat" ] ; then # restore only main / uat
 


### PR DESCRIPTION
Add `api_uat` case, this maps the `api_uat` env to the `uat` db snapshot

in scope of https://www.pivotaltracker.com/story/show/164978300

Background: database is restored from a snapshot for quicker bootstrap