### PR TITLE
Fix seed_peers undefined error

### DIFF
--- a/ansible/deploy.yml
+++ b/ansible/deploy.yml
@@ -172,7 +172,7 @@
           content: "{{ lookup('hashi_vault', 'secret=secret/aenode/peer_keys/{{ public_ipv4 }}/private:base64')|b64decode }}"
           dest: "{{ project_root }}/{{ node_config['keys']['dir'] }}/peer_key"
           mode: 0600
-        when: public_ipv4 in seed_peers
+        when: seed_peers is defined and public_ipv4 in seed_peers
         notify: "restart aeternity daemon"
         tags: [config, peer_keys]
 


### PR DESCRIPTION
Error for missing `seed_peers` var is thrown for `node_config` template when the key is not provided (i.e. it is not required by the node)

```
TASK [Copy node private peer key to keys/peer_key] *****************************
Friday 05 July 2019  14:03:28 +0000 (0:00:01.338)       0:00:27.404 ***********
fatal: [localhost]: FAILED! =>
  msg: |-
    The conditional check 'public_ipv4 in seed_peers' failed. The error was: error while evaluating conditional (public_ipv4 in seed_peers): Unable to look up a name or access an attribute in template string ({% if public_ipv4 in seed_peers %} True {% else %} False {% endif %}).
    Make sure your variable name does not contain invalid characters like '-': argument of type 'StrictUndefined' is not iterable      
    The error appears to have been in '/infrastructure/ansible/deploy.yml': line 170, column 9, but may
    be elsewhere in the file depending on the exact syntax problem.

    The offending line appears to be:


          - name: "Copy node private peer key to {{ node_config['keys']['dir'] }}/peer_key"
            ^ here
    We could be wrong, but this one looks like it might be an issue with
    missing quotes.  Always quote template expression brackets when they
    start a value. For instance:

        with_items:
          - {{ foo }}

    Should be written as:

        with_items:
          - "{{ foo }}"
```

Note: the error message does not pinpoint the real failure reason

in scope of https://www.pivotaltracker.com/story/show/165559131