### PR TITLE
Restore DB for monitoring envs

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -131,11 +131,11 @@ ansible-playbook \
     deploy.yml
 
 RESTORE_ENV=${env}
-if [ "$env" = "api_main" ] ; then
+if [[ "$env" = *"main"* ]] ; then
     RESTORE_ENV=main
 fi
 
-if [ "$env" = "api_uat" ] ; then
+if [[ "$env" = *"uat"* ]] ; then
     RESTORE_ENV=uat
 fi
 


### PR DESCRIPTION
Skip full db syncing for monitor nodes.

Background: This hack checks the deployment env and maps the appropriate db backup then copy it to the node, so it does not need to sync from 0. Check is refactored to 'string-contains' as there are 'api_uat', 'uat_mon' and probably others in the future.

Note: this should be refactored some times