### PR TITLE
Export region in playbook

### DIFF
--- a/ansible/async_provision.yml
+++ b/ansible/async_provision.yml
@@ -8,6 +8,7 @@
     var_bootstrap_version: "{{ bootstrap_version | default('master, true) }}"
     vault_role: ae-node
     var_package: "{{ package | default('http://s3.eu-central-1.amazonaws.com/aeternity-node-releases/aeternity-latest-ubuntu-x86_64.tar.gz', true) }}"
+    var_region: "{{ region | default('', true) }}"
 
   tasks:
     - name: Clone infrastructure repo
@@ -25,6 +26,7 @@
          --vault_role={{ vault_role }} \
          --env={{ env }} \
          --aeternity_package={{ var_package }} \
+         --region={{ var_region }} \
          >> /tmp/provision.log 2>&1
       async: 600
       poll: 15

--- a/ansible/vars/aeternity/main_mon.yml
+++ b/ansible/vars/aeternity/main_mon.yml
@@ -1,0 +1,44 @@
+public_ipv4: "{{ ansible_ec2_public_ipv4|default(ansible_ssh_host)|default(ansible_host)|default(inventory_hostname) }}"
+datadog_enabled: yes
+api_base_uri: http://{{ public_ipv4 }}:{{ node_config.http.external.port }}/v2
+monitoring_pubkey: "{{ lookup('hashi_vault', 'secret=secret/aenode/monitor/main/' + region + '/publisher:pubkey') }}"
+monitoring_privkey: "{{ lookup('hashi_vault', 'secret=secret/aenode/monitor/main/' + region + '/publisher:privkey') }}"
+
+node_config:
+  sync:
+    port: 3015
+
+  http:
+    external:
+      port: 3013
+    internal:
+      port: 3113
+
+  keys:
+    dir: keys
+    peer_password: secret
+
+  chain:
+    persist: true
+    db_path: "/data/db{{ db_version|mandatory }}"
+
+  logging:
+    level: warning
+
+  metrics:
+      # StatsD server and port
+      host: 127.0.0.1
+      port: 8125
+
+  fork_management:
+    network_id: "ae_mainnet"
+
+  monitoring:
+    active: true
+    publisher:
+      autostart: true
+      pubkey: "{{ monitoring_pubkey }}"
+      privkey: "{{ monitoring_privkey }}"
+      amount: 20000
+      interval: 10000
+      ttl: 10

--- a/ansible/vars/aeternity/uat_mon.yml
+++ b/ansible/vars/aeternity/uat_mon.yml
@@ -1,7 +1,7 @@
 public_ipv4: "{{ ansible_ec2_public_ipv4|default(ansible_ssh_host)|default(ansible_host)|default(inventory_hostname) }}"
 datadog_enabled: yes
 api_base_uri: http://{{ public_ipv4 }}:{{ node_config.http.external.port }}/v2
-monitoring_privkey: "{{ lookup('hashi_vault', 'secret=secret/mon/uat:privkey') }}"
+monitoring_privkey: "{{ lookup('hashi_vault', 'secret=secret/mon/uat_' + region + ':privkey') }}"
 
 node_config:
   sync:

--- a/ansible/vars/aeternity/uat_mon.yml
+++ b/ansible/vars/aeternity/uat_mon.yml
@@ -1,7 +1,8 @@
 public_ipv4: "{{ ansible_ec2_public_ipv4|default(ansible_ssh_host)|default(ansible_host)|default(inventory_hostname) }}"
 datadog_enabled: yes
 api_base_uri: http://{{ public_ipv4 }}:{{ node_config.http.external.port }}/v2
-monitoring_privkey: "{{ lookup('hashi_vault', 'secret=secret/mon/uat_' + region + ':privkey') }}"
+monitoring_pubkey: "{{ lookup('hashi_vault', 'secret=secret/aenode/monitor/uat/' + region + '/publisher:pubkey') }}"
+monitoring_privkey: "{{ lookup('hashi_vault', 'secret=secret/aenode/monitor/uat/' + region + '/publisher:privkey') }}"
 
 node_config:
   sync:
@@ -36,7 +37,7 @@ node_config:
     active: true
     publisher:
       autostart: true
-      pubkey: ak_JGMjbAS6UBCmsZR3ck1UR5KXLaBp1bsckf7cJiMDw6av5C3ie
+      pubkey: "{{ monitoring_privkey }}"
       privkey: "{{ monitoring_privkey }}"
       amount: 20000
       interval: 10000

--- a/ansible/vars/aeternity/uat_mon.yml
+++ b/ansible/vars/aeternity/uat_mon.yml
@@ -37,7 +37,7 @@ node_config:
     active: true
     publisher:
       autostart: true
-      pubkey: "{{ monitoring_privkey }}"
+      pubkey: "{{ monitoring_pubkey }}"
       privkey: "{{ monitoring_privkey }}"
       amount: 20000
       interval: 10000

--- a/test/terraform/test.tf
+++ b/test/terraform/test.tf
@@ -19,7 +19,7 @@ variable "package" {
 }
 
 provider "aws" {
-  version                 = "1.55"
+  version                 = "2.19.0"
   region                  = "ap-southeast-2"
   alias                   = "ap-southeast-2"
   shared_credentials_file = "/aws/credentials"
@@ -27,14 +27,13 @@ provider "aws" {
 }
 
 module "aws_deploy-test" {
-  source              = "github.com/aeternity/terraform-aws-aenode-deploy?ref=v1.0.0"
+  source              = "github.com/aeternity/terraform-aws-aenode-deploy?ref=v2.0.0"
   env                 = "${var.env_name}"
   envid               = "${var.envid}"
   bootstrap_version   = "${var.bootstrap_version}"
   vault_role          = "ae-node"
   vault_addr          = "${var.vault_addr}"
   user_data_file      = "user_data.bash"
-  spot_user_data_file = "user_data.bash"
 
   static_nodes = 1
   spot_nodes   = 1
@@ -43,7 +42,7 @@ module "aws_deploy-test" {
   instance_type = "t3.large"
   ami_name      = "aeternity-ubuntu-16.04-*"
 
-  additional_storage      = 1
+  additional_storage      = true
   additional_storage_size = 5
 
   aeternity = {


### PR DESCRIPTION
Allow use of different publisher accounts per monitoring node (1 node per region). Keys are stored in the vault grouped by region

Currently we are using single account with multiple nodes and this causes conflicting or confusing stats data.

Biggest problem is that nonces will be racing all the time and this will produce a lot of nonce errors (and tx rejects). Each node will try to increase the nonce +1 but their starting nonce will be the same, thus 2 nodes will try to post a transaction with the same nonce, one will be successful but the rest will fail (and produce nonce error in the logs). In time nonce might eventually sync, but the problem may occur again under certain conditions.