### PR TITLE
Place db of uat_mon to the additional storage

### DIFF
--- a/ansible/vars/aeternity/integration.yml
+++ b/ansible/vars/aeternity/integration.yml
@@ -2,6 +2,9 @@ public_ipv4: "{{ ansible_ec2_public_ipv4|default(ansible_ssh_host)|default(ansib
 datadog_enabled: yes
 api_base_uri: http://{{ public_ipv4 }}:{{ node_config.http.external.port }}/v2
 configure_peers: false
+additional_storage: true
+additional_storage_mountpoint: /data
+
 seed_peers:
   - "35.177.40.45"
 
@@ -27,7 +30,7 @@ node_config:
 
   chain:
     persist: true
-    db_path: "./db{{ db_version|mandatory }}"
+    db_path: "/data/db{{ db_version|mandatory }}"
     protocol_beneficiaries_enabled: true
     protocol_beneficiaries: ["ak_2A3PZPfMC2X7ZVy4qGXz2xh2Lbh79Q4UvZ5fdH7QVFocEgcKzU:109"]
 

--- a/ansible/vars/aeternity/uat.yml
+++ b/ansible/vars/aeternity/uat.yml
@@ -2,6 +2,9 @@ public_ipv4: "{{ ansible_ec2_public_ipv4|default(ansible_ssh_host)|default(ansib
 datadog_enabled: yes
 api_base_uri: http://{{ public_ipv4 }}:{{ node_config.http.external.port }}/v2
 configure_peers: false
+additional_storage: true
+additional_storage_mountpoint: /data
+
 seed_peers:
   - "52.10.46.160"
   - "18.195.109.60"
@@ -29,7 +32,7 @@ node_config:
 
   chain:
     persist: true
-    db_path: "./db{{ db_version|mandatory }}"
+    db_path: "/data/db{{ db_version|mandatory }}"
     protocol_beneficiaries_enabled: true
     protocol_beneficiaries: ["ak_2A3PZPfMC2X7ZVy4qGXz2xh2Lbh79Q4UvZ5fdH7QVFocEgcKzU:109"]
 

--- a/ansible/vars/aeternity/uat_mon.yml
+++ b/ansible/vars/aeternity/uat_mon.yml
@@ -3,6 +3,8 @@ datadog_enabled: yes
 api_base_uri: http://{{ public_ipv4 }}:{{ node_config.http.external.port }}/v2
 monitoring_pubkey: "{{ lookup('hashi_vault', 'secret=secret/aenode/monitor/uat/' + region + '/publisher:pubkey') }}"
 monitoring_privkey: "{{ lookup('hashi_vault', 'secret=secret/aenode/monitor/uat/' + region + '/publisher:privkey') }}"
+additional_storage: true
+additional_storage_mountpoint: /data
 
 node_config:
   sync:

--- a/ansible/vars/aeternity/uat_mon.yml
+++ b/ansible/vars/aeternity/uat_mon.yml
@@ -20,7 +20,7 @@ node_config:
 
   chain:
     persist: true
-    db_path: "./db{{ db_version|mandatory }}"
+    db_path: "/data/db{{ db_version|mandatory }}"
 
   logging:
     level: warning


### PR DESCRIPTION
Default node space (8GB) soon will not be enough to store the db. 
Currently `uat` nodes do not have external disk space attached and db is stored in the path of the node which takes space from the root volume.

Notes: This is just a configuration of `uat_mon` nodes to point to the additional space (which is mounted in `/data/`). It will be used only when nodes are redeployed with this bootstrap and have been terraformed with `additional_storage= true`.