### PR TITLE
Fix snapshot restore

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,6 @@
 DEPLOY_DOWNTIME ?= 0
 ROLLING_UPDATE ?= 100%
 BACKUP_SUFFIX ?= backup
-BACKUP_DIR ?= /tmp/mnesia_backups
 TF_LOCK_TIMEOUT=5m
 VAULT_TOKENS_TTL ?= 4h
 SEED_CHECK_ENVS = main uat next
@@ -89,8 +88,7 @@ endif
 	cd ansible && $(ENV) ansible-playbook \
 		--limit="tag_role_aenode:&tag_env_$(BACKUP_ENV)" \
 		-e ansible_python_interpreter=/var/venv/bin/python \
-		-e download_dir=$(BACKUP_DIR) \
-		-e backup_suffix=$(BACKUP_SUFFIX) \
+		-e snapshot_suffix=$(BACKUP_SUFFIX) \
 		-e db_version=$(BACKUP_DB_VERSION) \
 		-e env=$(BACKUP_ENV) \
 		mnesia_snapshot.yml

--- a/ansible/mnesia_snapshot.yml
+++ b/ansible/mnesia_snapshot.yml
@@ -1,9 +1,14 @@
 ---
-# Playbook used create mnesia snapshoot and upload it to S3
+# Playbook used create mnesia snapshot and upload it to S3
 
 - name: Backup, archive and download Mnesia database
   hosts: "{{ ansible_play_hosts | last }}"
   remote_user: aeternity
+
+  vars:
+    snapshot_suffix: snapshot
+    snapshot_filename: "mnesia_{{ env }}_v-{{ db_version }}_{{ ansible_ssh_host|default(inventory_hostname) }}_{{ snapshot_suffix }}.tgz"
+
   tasks:
     - name: Include configuration variables
       include_vars: vars/snapshot.yml
@@ -21,17 +26,25 @@
 
     - meta: flush_handlers
 
-    - name: Archive Mnesia Directory
+    - name: Archive Mnesia Directory (no additional storage)
       archive:
-        format: "{{ format }}"
-        path: "{{ project_root + '/' if additional_storage is not defined else '' }}{{ node_config.chain.db_path }}"
-        dest: /tmp/{{ backup_archive_filename }}
+        format: gz
+        path: "{{ project_root }}/{{ node_config.chain.db_path }}"
+        dest: /tmp/{{ snapshot_filename }}
+      when: additional_storage is not defined
+
+    - name: Archive Mnesia Directory (with additional storage)
+      archive:
+        format: gz
+        path: "{{ project_root }}/{{ node_config.chain.db_path }}"
+        dest: /tmp/{{ snapshot_filename }}
+      when: additional_storage is defined
 
     - name: Upload backup to S3 bucket
       aws_s3:
-        bucket: "{{ backup_bucket }}"
-        object: "{{ backup_archive_filename }}"
-        src: /tmp/{{ backup_archive_filename }}
+        bucket: "{{ snapshots_bucket }}"
+        object: "{{ snapshot_filename }}"
+        src: /tmp/{{ snapshot_filename }}
         mode: put
         aws_access_key: "{{ lookup('env','AWS_ACCESS_KEY_ID') }}"
         aws_secret_key: "{{ lookup('env','AWS_SECRET_ACCESS_KEY') }}"
@@ -39,9 +52,9 @@
 
     - name: Upload backup to S3 bucket latest
       aws_s3:
-        bucket: "{{ backup_bucket }}"
-        object: "{{ backup_archive_filename_latest }}"
-        src: /tmp/{{ backup_archive_filename }}
+        bucket: "{{ snapshots_bucket }}"
+        object: "{{ snapshots_filename_latest }}"
+        src: /tmp/{{ snapshot_filename }}
         mode: put
         aws_access_key: "{{ lookup('env','AWS_ACCESS_KEY_ID') }}"
         aws_secret_key: "{{ lookup('env','AWS_SECRET_ACCESS_KEY') }}"
@@ -53,7 +66,7 @@
         state: absent
       loop:
         - /tmp/backup
-        - /tmp/{{ backup_archive_filename }}
+        - /tmp/{{ snapshot_filename }}
 
     - name: Start node
       command: "/bin/true"

--- a/ansible/mnesia_snapshot.yml
+++ b/ansible/mnesia_snapshot.yml
@@ -8,6 +8,7 @@
   vars:
     snapshot_suffix: snapshot
     snapshot_filename: "mnesia_{{ env }}_v-{{ db_version }}_{{ ansible_ssh_host|default(inventory_hostname) }}_{{ snapshot_suffix }}.tgz"
+    snapshot_path: "{{ snapshots_dir|default('/tmp/snapshots') }}/{{ snapshot_filename }}"
 
   tasks:
     - name: Include configuration variables
@@ -26,25 +27,30 @@
 
     - meta: flush_handlers
 
-    - name: Archive Mnesia Directory (no additional storage)
+    - name: Ensure Mnesia snapshots dir exists ({{ snapshots_dir }})
+      file:
+        path: "{{ snapshots_dir }}"
+        state: directory
+
+    - name: Archive Mnesia Directory ({{ project_root }}/{{ node_config.chain.db_path }})
       archive:
         format: gz
         path: "{{ project_root }}/{{ node_config.chain.db_path }}"
-        dest: /tmp/{{ snapshot_filename }}
+        dest: "{{ snapshot_path }}"
       when: additional_storage is not defined
 
-    - name: Archive Mnesia Directory (with additional storage)
+    - name: Archive Mnesia Directory ({{ node_config.chain.db_path }})
       archive:
         format: gz
-        path: "{{ project_root }}/{{ node_config.chain.db_path }}"
-        dest: /tmp/{{ snapshot_filename }}
+        path: "{{ node_config.chain.db_path }}"
+        dest: "{{ snapshot_path }}"
       when: additional_storage is defined
 
-    - name: Upload backup to S3 bucket
+    - name: Upload snapshot to S3 bucket ({{ snapshots_bucket }}/{{ snapshot_filename }})
       aws_s3:
         bucket: "{{ snapshots_bucket }}"
         object: "{{ snapshot_filename }}"
-        src: /tmp/{{ snapshot_filename }}
+        src: "{{ snapshot_path }}"
         mode: put
         aws_access_key: "{{ lookup('env','AWS_ACCESS_KEY_ID') }}"
         aws_secret_key: "{{ lookup('env','AWS_SECRET_ACCESS_KEY') }}"
@@ -54,19 +60,16 @@
       aws_s3:
         bucket: "{{ snapshots_bucket }}"
         object: "{{ snapshots_filename_latest }}"
-        src: /tmp/{{ snapshot_filename }}
+        src: "{{ snapshot_path }}"
         mode: put
         aws_access_key: "{{ lookup('env','AWS_ACCESS_KEY_ID') }}"
         aws_secret_key: "{{ lookup('env','AWS_SECRET_ACCESS_KEY') }}"
         security_token: "{{ lookup('env','AWS_SESSION_TOKEN') }}"
 
-    - name: Remove Mnesia backups
+    - name: Delete local Mnesia snapshots ({{ snapshots_dir }})
       file:
-        path:  "{{ item }}"
+        path: "{{ snapshots_dir }}"
         state: absent
-      loop:
-        - /tmp/backup
-        - /tmp/{{ snapshot_filename }}
 
     - name: Start node
       command: "/bin/true"

--- a/ansible/mnesia_snapshot.yml
+++ b/ansible/mnesia_snapshot.yml
@@ -37,14 +37,16 @@
         format: gz
         path: "{{ project_root }}/{{ node_config.chain.db_path }}"
         dest: "{{ snapshot_path }}"
-      when: additional_storage is not defined
+      when: additional_storage is not defined or not addtional_storage
 
     - name: Archive Mnesia Directory ({{ node_config.chain.db_path }})
       archive:
         format: gz
         path: "{{ node_config.chain.db_path }}"
         dest: "{{ snapshot_path }}"
-      when: additional_storage is defined
+      when:
+        - additional_storage is defined
+        - additional_storage
 
     - name: Upload snapshot to S3 bucket ({{ snapshots_bucket }}/{{ snapshot_filename }})
       aws_s3:

--- a/ansible/mnesia_snapshot_restore.yml
+++ b/ansible/mnesia_snapshot_restore.yml
@@ -29,7 +29,7 @@
 
     - meta: flush_handlers
 
-    - name: Restore Mnesia database
+    - name: Restore Mnesia database (with additional storage)
       unarchive:
         remote_src: yes
         src: /tmp/{{ restore_snapshot_filename }}
@@ -38,7 +38,7 @@
         - additional_storage is defined
         - additional_storage
 
-    - name: Restore Mnesia database
+    - name: Restore Mnesia database (without additional storage)
       unarchive:
         remote_src: yes
         src: /tmp/{{ restore_snapshot_filename }}

--- a/ansible/mnesia_snapshot_restore.yml
+++ b/ansible/mnesia_snapshot_restore.yml
@@ -5,6 +5,9 @@
   hosts: all
   remote_user: aeternity
 
+  vars:
+    snapshot_path: "{{ snapshots_dir|default('/tmp/snapshots') }}/{{ restore_snapshot_filename|mandatory }}"
+
   tasks:
     - name: Include configuration variables
       include_vars: vars/snapshot.yml
@@ -15,11 +18,16 @@
         - "../vars/aeternity/{{ env }}.yml"
       tags: [config, node_config]
 
-    - name: Download backup to S3 bucket latest
+    - name: Ensure Mnesia snapshots dir exists ({{ snapshots_dir }})
+      file:
+        path: "{{ snapshots_dir }}"
+        state: directory
+
+    - name: Download Mnesia snapshot {{ restore_snapshot_filename }}
       aws_s3:
         bucket: "{{ snapshots_bucket }}"
         object: "{{ restore_snapshot_filename }}"
-        dest: /tmp/{{ restore_snapshot_filename }}
+        dest: "{{ snapshot_path }}"
         mode: get
 
     - name: Stop node
@@ -29,30 +37,27 @@
 
     - meta: flush_handlers
 
-    - name: Restore Mnesia database (with additional storage)
+    - name: Restore Mnesia database to {{ additional_storage_mountpoint }}/
       unarchive:
         remote_src: yes
-        src: /tmp/{{ restore_snapshot_filename }}
+        src: "{{ snapshot_path }}"
         dest: "{{ additional_storage_mountpoint }}/"
       when:
         - additional_storage is defined
         - additional_storage
 
-    - name: Restore Mnesia database (without additional storage)
+    - name: Restore Mnesia database to {{ project_root }}/
       unarchive:
         remote_src: yes
-        src: /tmp/{{ restore_snapshot_filename }}
+        src: "{{ snapshot_path }}"
         dest: "{{ project_root }}/"
       when:
         - additional_storage is not defined or not additional_storage
 
-    - name: Remove Mnesia backups
+    - name: Delete local Mnesia snapshots ({{ snapshots_dir }})
       file:
-        path:  "{{ item }}"
+        path: "{{ snapshots_dir }}"
         state: absent
-      loop:
-        - /tmp/backup
-        - /tmp/{{ restore_snapshot_filename }}
 
     - name: Start node
       command: "/bin/true"

--- a/ansible/mnesia_snapshot_restore.yml
+++ b/ansible/mnesia_snapshot_restore.yml
@@ -1,5 +1,5 @@
 ---
-# Playbook used to download mnesia snapshoot for env from S3 and restore it to give node
+# Playbook used to download mnesia snapshot for env from S3 and restore it to give node
 
 - name: Backup, archive and download Mnesia database
   hosts: all
@@ -17,9 +17,9 @@
 
     - name: Download backup to S3 bucket latest
       aws_s3:
-        bucket: "{{ backup_bucket }}"
-        object: "{{ backup_archive_filename_latest }}"
-        dest: /tmp/{{ backup_archive_filename_latest }}
+        bucket: "{{ snapshots_bucket }}"
+        object: "{{ restore_snapshot_filename }}"
+        dest: /tmp/{{ restore_snapshot_filename }}
         mode: get
 
     - name: Stop node
@@ -32,8 +32,19 @@
     - name: Restore Mnesia database
       unarchive:
         remote_src: yes
-        src: /tmp/{{ backup_archive_filename_latest }}
-        dest: "{{ additional_storage_mountpoint if additional_storage is defined and additional_storage else project_root }}/"
+        src: /tmp/{{ restore_snapshot_filename }}
+        dest: "{{ additional_storage_mountpoint }}/"
+      when:
+        - additional_storage is defined
+        - additional_storage
+
+    - name: Restore Mnesia database
+      unarchive:
+        remote_src: yes
+        src: /tmp/{{ restore_snapshot_filename }}
+        dest: "{{ project_root }}/"
+      when:
+        - additional_storage is not defined or not additional_storage
 
     - name: Remove Mnesia backups
       file:
@@ -41,7 +52,7 @@
         state: absent
       loop:
         - /tmp/backup
-        - /tmp/{{ backup_archive_filename_latest }}
+        - /tmp/{{ restore_snapshot_filename }}
 
     - name: Start node
       command: "/bin/true"

--- a/ansible/vars/snapshot.yml
+++ b/ansible/vars/snapshot.yml
@@ -3,3 +3,4 @@ aeternity_bin: "{{ ansible_env.HOME }}/node/bin/aeternity"
 snapshots_bucket: aeternity-database-backups
 snapshots_filename_latest: "mnesia_{{ env }}_v-{{ db_version }}_latest.tgz"
 restore_snapshot_filename: "{{ snapshots_filename_latest }}" # default for BC
+snapshots_dir: "{{ additional_storage_mountpoint|default('/tmp') }}/snapshots"

--- a/ansible/vars/snapshot.yml
+++ b/ansible/vars/snapshot.yml
@@ -1,8 +1,5 @@
 project_root: "{{ ansible_env.HOME }}/node"
 aeternity_bin: "{{ ansible_env.HOME }}/node/bin/aeternity"
-download_dir: /tmp/mnesia_backups
-backup_bucket: aeternity-database-backups
-backup_suffix: backup
-format: gz
-backup_archive_filename: "mnesia_{{ env }}_v-{{ db_version }}_{{ ansible_ssh_host|default(inventory_hostname) }}_{{ backup_suffix }}.{{ format }}"
-backup_archive_filename_latest: "mnesia_{{ env }}_v-{{ db_version }}_latest.{{ format }}"
+snapshots_bucket: aeternity-database-backups
+snapshots_filename_latest: "mnesia_{{ env }}_v-{{ db_version }}_latest.tgz"
+restore_snapshot_filename: "{{ snapshots_filename_latest }}" # default for BC

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -137,7 +137,7 @@ ansible-playbook \
     -e db_version=1 \
     deploy.yml
 
-if [ "$RESTORE_DATABASE" = true ] && [ -n "$snapshot_filename" ]; then
+if [ "$RESTORE_DATABASE" = true ] && [ -n "$snapshot_filename" ] && [ "$snapshot_filename" != "empty" ]; then
     ansible-playbook \
         -i localhost, -c local \
         -e ansible_python_interpreter=$(which python3) \


### PR DESCRIPTION
In scope of https://www.pivotaltracker.com/story/show/167595374

This is _soft_ backward compatibility break, that is, an environment that lack `snapshot_filename` tag will not be restored from a snapshot, however the environment should provision and sync just fine.