### PR TITLE
Detect additional storage device

### DIFF
--- a/ansible/tasks/additional_storage.yml
+++ b/ansible/tasks/additional_storage.yml
@@ -19,25 +19,46 @@
         - "vars/aeternity/{{ env }}.yml"
       skip: true
 
-- name: "Wait for /dev/nvme1n1 to become present"
+- name: Check that the /dev/xvdh exists
+  stat:
+    path: /dev/xvda1
+  register: xvdh_dev
+  when:
+    - additional_storage is defined
+    - additional_storage
+    - additional_storage_mountpoint is defined
+    - is_aws
+
+- name: Detect additional storage device name
+  set_fact:
+    additional_storage_dev: "{{ (xvdh_dev.stat is defined and xvdh_dev.stat.exists) | ternary('/dev/xvdh', '/dev/nvme1n1') }}"
+  tags: [always]
+  when:
+    - xvdh_dev is defined
+    - additional_storage is defined
+    - additional_storage
+    - additional_storage_mountpoint is defined
+    - is_aws
+
+- name: "Wait for {{ additional_storage_dev }} to become present"
   wait_for:
-    path: /dev/nvme1n1
+    path: "{{ additional_storage_dev }}"
     state: present
-  when: additional_storage is defined and additional_storage and is_aws
+  when: additional_storage_dev is defined
 
 - name: Create a xfs filesystem on /dev/nvme1n1
   filesystem:
     fstype: xfs
-    dev: /dev/nvme1n1
-  when: additional_storage is defined and additional_storage and is_aws
+    dev: "{{ additional_storage_dev }}"
+  when: additional_storage_dev is defined
 
 - name: Mount disk {{ additional_storage_mountpoint }}
   mount:
     path: "{{ additional_storage_mountpoint }}"
-    src: /dev/nvme1n1
+    src: "{{ additional_storage_dev }}"
     fstype: xfs
     state: mounted
-  when: additional_storage is defined and additional_storage and is_aws
+  when: additional_storage_dev is defined
 
 - name: Make sure that node will be able to access storage
   file:
@@ -45,4 +66,4 @@
     owner: "{{ project_user }}"
     group: "{{ project_user }}"
     mode: 0744
-  when: additional_storage is defined and additional_storage and is_aws
+  when: additional_storage_dev is defined


### PR DESCRIPTION
tl;dr
Certain instance types have different additional storage device names depending on the storage type and hardware. So we need to check what is available.

in scope of https://www.pivotaltracker.com/story/show/167561756

Background:
Seems that same instance type might have different devices at startup although we expect the same specs from the VM. Inconsistency appear even between regions.

For instance in Singapore, an m4.large + 2nd Standard volume have /xvd devices, while m5.large + standard have /nvme volumes. Despite having an NVMe it works with limited speed similar to a magnetic disk.

I have tracked that instances which have `/dev/xvd*` drives available at boottime, would not have additional storage named `/dev/nvme1`

https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/device_naming.html
(the list above is just for reference to naming, but it actually refers to the root volumes, while attached volumes seems to have some differences)

`xvd*` devices are listed as Standard which is the default for all instances and map to magnetic HDDs and they appear as soon as the machine boots up, while NVMe drives require a driver to be loaded, which happens some time later.

In addition it is not possible to check for `/dev/nvme1` from the beginning because it has a delay to become available. At the point we need to configure the volume mounting, we can not distinguish at this time will it be ever available for this instance and wait for it, or it is not configured to have it at all.
