### PR TITLE
Enable internal API listener on mainnet API gateway nodes

### DIFF
--- a/ansible/vars/aeternity/api_main.yml
+++ b/ansible/vars/aeternity/api_main.yml
@@ -15,6 +15,8 @@ node_config:
       port: 3013
     internal:
       port: 3113
+      listen_address: 0.0.0.0
+      debug_endpoints: true
 
   keys:
     dir: keys


### PR DESCRIPTION
In scope of https://www.pivotaltracker.com/story/show/168074857