### PR TITLE
Force curl to fail on http error

### DIFF
--- a/scripts/upload-github-release-assets.sh
+++ b/scripts/upload-github-release-assets.sh
@@ -63,5 +63,5 @@ do
   # Construct url
   GH_ASSET="https://uploads.github.com/repos/$owner/$repo/releases/$id/assets?name=$(basename $filename)"
 
-  curl --data-binary @"$filename" -H "Authorization: token $github_api_token" -H "Content-Type: application/octet-stream" $GH_ASSET
+  curl -f --data-binary @"$filename" -H "$AUTH" -H "Content-Type: application/octet-stream" "$GH_ASSET"
 done


### PR DESCRIPTION
+ `-f` fails with exit code for non-success http responses
+ use the available AUTH var
+ properly escape/quote url
