### PR TITLE
Fix monitoring environments config

### DIFF
--- a/ansible/vars/aeternity/main_mon.yml
+++ b/ansible/vars/aeternity/main_mon.yml
@@ -1,8 +1,9 @@
 public_ipv4: "{{ ansible_ec2_public_ipv4|default(ansible_ssh_host)|default(ansible_host)|default(inventory_hostname) }}"
 datadog_enabled: yes
 api_base_uri: http://{{ public_ipv4 }}:{{ node_config.http.external.port }}/v2
-monitoring_pubkey: "{{ lookup('hashi_vault', 'secret=secret/aenode/monitor/main/' + region + '/publisher:pubkey') }}"
-monitoring_privkey: "{{ lookup('hashi_vault', 'secret=secret/aenode/monitor/main/' + region + '/publisher:privkey') }}"
+monitoring_vault_path: "{{ 'secret/aenode/monitor/main/' + ansible_ec2_placement_region|default('global') + '/publisher' }}"
+monitoring_pubkey: "{{ lookup('hashi_vault', 'secret=' + monitoring_vault_path + ':pubkey') }}"
+monitoring_privkey: "{{ lookup('hashi_vault', 'secret=' + monitoring_vault_path + ':privkey') }}"
 additional_storage: true
 additional_storage_mountpoint: /data
 

--- a/ansible/vars/aeternity/uat_mon.yml
+++ b/ansible/vars/aeternity/uat_mon.yml
@@ -1,8 +1,9 @@
 public_ipv4: "{{ ansible_ec2_public_ipv4|default(ansible_ssh_host)|default(ansible_host)|default(inventory_hostname) }}"
 datadog_enabled: yes
 api_base_uri: http://{{ public_ipv4 }}:{{ node_config.http.external.port }}/v2
-monitoring_pubkey: "{{ lookup('hashi_vault', 'secret=secret/aenode/monitor/uat/' + region + '/publisher:pubkey') }}"
-monitoring_privkey: "{{ lookup('hashi_vault', 'secret=secret/aenode/monitor/uat/' + region + '/publisher:privkey') }}"
+monitoring_vault_path: "{{ 'secret/aenode/monitor/uat/' + ansible_ec2_placement_region|default('global') + '/publisher' }}"
+monitoring_pubkey: "{{ lookup('hashi_vault', 'secret=' + monitoring_vault_path + ':pubkey') }}"
+monitoring_privkey: "{{ lookup('hashi_vault', 'secret=' + monitoring_vault_path + ':privkey') }}"
 additional_storage: true
 additional_storage_mountpoint: /data
 


### PR DESCRIPTION
Without this change the `region` variable is mandatory, so in a remote run case it have to be provided, therefore one can't run any dependant (on the config) playbook that runs over multiple regions.