### PR TITLE
Cleanup obsolete and default variables

### DIFF
--- a/ansible/vars/aeternity/api_main.yml
+++ b/ansible/vars/aeternity/api_main.yml
@@ -1,10 +1,9 @@
 public_ipv4: "{{ ansible_ec2_public_ipv4|default(ansible_ssh_host)|default(ansible_host)|default(inventory_hostname) }}"
 datadog_enabled: yes
-api_base_uri: http://{{ public_ipv4 }}:{{ node_config.http.external.port }}/v2
-configure_peers: false
 seed_peers: []
 additional_storage: true
 additional_storage_mountpoint: /data
+
 node_config:
   sync:
     port: 3015

--- a/ansible/vars/aeternity/api_uat.yml
+++ b/ansible/vars/aeternity/api_uat.yml
@@ -1,17 +1,10 @@
 public_ipv4: "{{ ansible_ec2_public_ipv4|default(ansible_ssh_host)|default(ansible_host)|default(inventory_hostname) }}"
 datadog_enabled: yes
-api_base_uri: http://{{ public_ipv4 }}:{{ node_config.http.external.port }}/v2
-configure_peers: false
 seed_peers: []
 additional_storage: true
 additional_storage_mountpoint: /data
-node_config:
-  peers:
-    - aenode://pp_QU9CvhAQH56a2kA15tCnWPRJ2srMJW8ZmfbbFTAy7eG4o16Bf@52.10.46.160:3015
-    - aenode://pp_2vhFb3HtHd1S7ynbpbFnEdph1tnDXFSfu4NGtq46S2eM5HCdbC@18.195.109.60:3015
-    - aenode://pp_27xmgQ4N1E3QwHyoutLtZsHW5DSW4zneQJ3CxT5JbUejxtFuAu@13.250.162.250:3015
-    - aenode://pp_DMLqy7Zuhoxe2FzpydyQTgwCJ52wouzxtHWsPGo51XDcxc5c8@13.53.161.215:3015
 
+node_config:
   http:
     external:
       port: 3013

--- a/ansible/vars/aeternity/dev1.yml
+++ b/ansible/vars/aeternity/dev1.yml
@@ -1,7 +1,5 @@
 public_ipv4: "{{ ansible_ec2_public_ipv4|default(ansible_ssh_host)|default(ansible_host)|default(inventory_hostname) }}"
 datadog_enabled: yes
-api_base_uri: http://{{ public_ipv4 }}:{{ node_config.http.external.port }}/v2
-configure_peers: true
 seed_peers: []
 
 node_config:

--- a/ansible/vars/aeternity/dev2.yml
+++ b/ansible/vars/aeternity/dev2.yml
@@ -1,7 +1,5 @@
 public_ipv4: "{{ ansible_ec2_public_ipv4|default(ansible_ssh_host)|default(ansible_host)|default(inventory_hostname) }}"
 datadog_enabled: no
-api_base_uri: http://{{ public_ipv4 }}:{{ node_config.http.external.port }}/v2
-configure_peers: true
 seed_peers: []
 
 node_config:

--- a/ansible/vars/aeternity/integration.yml
+++ b/ansible/vars/aeternity/integration.yml
@@ -1,20 +1,10 @@
 public_ipv4: "{{ ansible_ec2_public_ipv4|default(ansible_ssh_host)|default(ansible_host)|default(inventory_hostname) }}"
 datadog_enabled: yes
-api_base_uri: http://{{ public_ipv4 }}:{{ node_config.http.external.port }}/v2
-configure_peers: false
 additional_storage: true
 additional_storage_mountpoint: /data
-
-seed_peers:
-  - "35.177.40.45"
+seed_peers: []
 
 node_config:
-  peers:
-    - "aenode://pp_QU9CvhAQH56a2kA15tCnWPRJ2srMJW8ZmfbbFTAy7eG4o16Bf@52.10.46.160:3015"
-    - "aenode://pp_2vhFb3HtHd1S7ynbpbFnEdph1tnDXFSfu4NGtq46S2eM5HCdbC@18.195.109.60:3015"
-    - "aenode://pp_27xmgQ4N1E3QwHyoutLtZsHW5DSW4zneQJ3CxT5JbUejxtFuAu@13.250.162.250:3015"
-    - "aenode://pp_DMLqy7Zuhoxe2FzpydyQTgwCJ52wouzxtHWsPGo51XDcxc5c8@13.53.161.215:3015"
-
   sync:
     port: 3015
 
@@ -31,8 +21,6 @@ node_config:
   chain:
     persist: true
     db_path: "/data/db{{ db_version|mandatory }}"
-    protocol_beneficiaries_enabled: true
-    protocol_beneficiaries: ["ak_2A3PZPfMC2X7ZVy4qGXz2xh2Lbh79Q4UvZ5fdH7QVFocEgcKzU:109"]
 
   mining:
     autostart: true

--- a/ansible/vars/aeternity/main.yml
+++ b/ansible/vars/aeternity/main.yml
@@ -1,10 +1,7 @@
 public_ipv4: "{{ ansible_ec2_public_ipv4|default(ansible_ssh_host)|default(ansible_host)|default(inventory_hostname) }}"
 datadog_enabled: yes
-api_base_uri: http://{{ public_ipv4 }}:{{ node_config.http.external.port }}/v2
-configure_peers: false
 additional_storage: true
 additional_storage_mountpoint: /data
-
 seed_peers:
   - "18.136.37.63"
   - "52.220.198.72"
@@ -46,49 +43,8 @@ seed_peers:
   - "13.53.162.212"
   - "13.53.89.32"
   - "13.53.78.163"
-node_config:
-  peers:
-    - "aenode://pp_2L8A5vSjnkLtfFNpJNgP9HbmGLD7ZAGFxoof47N8L4yyLAyyMi@18.136.37.63:3015"
-    - "aenode://pp_2gPZjuPnJnTVEbrB9Qgv7f4MdhM4Jh6PD22mB2iBA1g7FRvHTk@52.220.198.72:3015"
-    - "aenode://pp_tVdaaX4bX54rkaVEwqE81hCgv6dRGPPwEVsiZk41GXG1A4gBN@3.16.242.93:3015"
-    - "aenode://pp_2mwr9ikcyUDUWTeTQqdu8WJeQs845nYPPqjafjcGcRWUx4p85P@3.17.30.101:3015"
-    - "aenode://pp_2CAJwwmM2ZVBHYFB6na1M17roQNuRi98k6WPFcoBMfUXvsezVU@13.58.177.66:3015"
-    - "aenode://pp_vxK2ikV9djG8MXmDnYYs338ETEsaUPweZrc2S54L3scxBfncU@13.250.190.66:3015"
-    - "aenode://pp_28si4QQ4YkjpZdo5cER7nxQodT2cMv7uNLBzUmaTkfU7EVHFH9@34.218.57.207:3015"
-    - "aenode://pp_iLdkHHPrQByhAEkAf9SoBZwH5gsbBv6UKB72nC82P5od7PMXc@34.209.38.2:3015"
-    - "aenode://pp_H4ooofyixJE6weqsgzKMKTdjZwEWb2BMSWqdFqbwZjssvtUEZ@18.217.69.24:3015"
-    - "aenode://pp_2qPAV7cYcHBK8MDo7neB2p1ow5Bmu1o56EUtnVv19ytuZ3pTtX@3.0.217.255:3015"
-    - "aenode://pp_2eu9njAqnd2s9nfSHNCHMbw96dajSATz1rgT6PokH2Lsa531Sp@3.17.15.122:3015"
-    - "aenode://pp_SFA9D5wc9uZ2amhL7nmXSmcv4qBthKKC64RdFy5ZWGZAbSkDt@3.17.30.125:3015"
-    - "aenode://pp_21DNLkjdBuoN7EajkK3ePfRMHbyMkhcuW5rJYBQsXNPDtu3v9n@35.166.231.86:3015"
-    - "aenode://pp_RKVZjm7UKPLGvyKWqVZN1pXN6CTCxfmYz2HkNL2xiAhLVd2ho@52.11.110.179:3015"
-    - "aenode://pp_AnPnGst52qzh7ii8KUzHHFwFGiXxyF2TALhds9LPguAxJJqKd@54.214.159.45:3015"
-    - "aenode://pp_2u68ui39npbsjDVAy7Q1vBYFxfgaV3AWbXL8UB38TuKsgehHF1@52.88.74.110:3015"
-    - "aenode://pp_26SjCczbcdG49nC8wWh3ZUZna6eyF9rbpFymSc6wKyCiten1LQ@3.0.221.40:3015"
-    - "aenode://pp_Xv6KMd1612pLWznW37s2fx79QMHGbLZuXTyFvuXRrHSNb8s5o@18.218.172.119:3015"
-    - "aenode://pp_XpZVMtsbg39Rm69aBP3m2Q245ght8MNUGN1omBr7xJmd4goxR@52.40.117.141:3015"
-    - "aenode://pp_21fv4vH2GbmL35gb6tWhwFQjMnprftuGQ4Xx97VehSM8eQdB7U@34.211.251.83:3015"
-    - "aenode://pp_sGegC48UrvDA7cvvUU3GPTze9wNUnnK1P4q46mL5jAFddNrbD@13.250.144.60:3015"
-    - "aenode://pp_cVrCJWsg2vyWnRerEpLyB6ut6A8AA1MchQWAheRFNWpRWHXHJ@35.163.118.175:3015"
-    - "aenode://pp_2dWtS7LECJwjkRXQKoDP3mspdVJ4TPhwBfkiWMPSPMNYyT7jzn@3.0.12.164:3015"
-    - "aenode://pp_2aAEHdDFNbqH23HdZqu6HMtQmaE6rvLQuDZqEEWndkNbWunyuY@18.216.167.138:3015"
-    - "aenode://pp_2R7a7JHzfZQU5Ta7DJnFiqRr7ayCcAVakqYzJ2mvZj5k4ms5mV@3.17.15.239:3015"
-    - "aenode://pp_2Vi6BTNLoFyyYCmAFWxcfRAmHKfb7gWPj8p73uqb9MtW3dXEbG@3.0.86.27:3015"
-    - "aenode://pp_8nn6ypcwkaXxJfPGq7DCpBpf9FNfmkXPvGCjJFnLzvwjhCMEH@52.26.157.37:3015"
-    - "aenode://pp_zUqmdQBnJjBKjrcVgJgEJU36mjJnUT7z59p8UVp5f6vA9Taxa@3.17.17.128:3015"
-    - "aenode://pp_QkNjQbJL3Ab1TVG5GesKuZTixBdXEutUtxG677mVu9D4mMNRr@13.228.202.140:3015"
-    - "aenode://pp_2jtDgarjfr7S5NBZpBBx3fgn3wdtLb24UmiYGtVCGzF6x7Bytb@52.77.168.79:3015"
-    - "aenode://pp_7N7dkCbg39MYzQv3vCrmjVNfy6QkoVmJe3VtiZ3HRncvTWAAX@13.53.114.199:3015"
-    - "aenode://pp_22FndjTkMMXZ5gunCTUyeMPbgoL53smqpM4m1Jz5fVuJmPXm24@13.53.149.181:3015"
-    - "aenode://pp_Xgsqi4hYAjXn9BmrU4DXWT7jURy2GoBPmrHfiCoDVd3UPQYcU@13.53.164.121:3015"
-    - "aenode://pp_vTDXS3HJrwJecqnPqX3iRxKG5RBRz9MdicWGy8p9hSdyhAY4S@13.53.77.98:3015"
-    - "aenode://pp_2LnQXCmGqEJymtHAeUGjgcXU7dPLBbsut9rAXDG3nb7sCQK4fN@13.53.213.137:3015"
-    - "aenode://pp_22fVESEbuKNaQWNTWH45PLH7tazAKHev4PCdKBmuVgU1BC7mKu@13.53.51.175:3015"
-    - "aenode://pp_2HjB1wZrAubYUCH3jfosMaWV9ZVq6GP3PKAG8CVfQPxKwFcLsw@13.53.161.210:3015"
-    - "aenode://pp_2QPVSDntnXzVpcjhAiiWCsXbP5WyAof9erGP4Wr47F8dVY9Nwy@13.53.162.212:3015"
-    - "aenode://pp_NPrJPXfzBU8da5Ufy2o2LmyHXhLX733NPHER2Xh3cTcbK2BDD@13.53.78.163:3015"
-    - "aenode://pp_27VNp1gHQQsNa2hBPB7na6CUCtvobqAe7sQmPKBW4G3v6uEq9s@13.53.89.32:3015"
 
+node_config:
   sync:
     port: 3015
     max_gossip: 100

--- a/ansible/vars/aeternity/main_mon.yml
+++ b/ansible/vars/aeternity/main_mon.yml
@@ -1,6 +1,5 @@
 public_ipv4: "{{ ansible_ec2_public_ipv4|default(ansible_ssh_host)|default(ansible_host)|default(inventory_hostname) }}"
 datadog_enabled: yes
-api_base_uri: http://{{ public_ipv4 }}:{{ node_config.http.external.port }}/v2
 monitoring_vault_path: "{{ 'secret/aenode/monitor/main/' + ansible_ec2_placement_region|default('global') + '/publisher' }}"
 monitoring_pubkey: "{{ lookup('hashi_vault', 'secret=' + monitoring_vault_path + ':pubkey') }}"
 monitoring_privkey: "{{ lookup('hashi_vault', 'secret=' + monitoring_vault_path + ':privkey') }}"

--- a/ansible/vars/aeternity/next.yml
+++ b/ansible/vars/aeternity/next.yml
@@ -1,8 +1,6 @@
 public_ipv4: "{{ ansible_ec2_public_ipv4|default(ansible_ssh_host)|default(ansible_host)|default(inventory_hostname) }}"
 datadog_enabled: yes
-api_base_uri: http://{{ public_ipv4 }}:{{ node_config.http.external.port }}/v2
 seed_peers: [18.130.100.58]
-configure_peers: false
 
 node_config:
   peers:

--- a/ansible/vars/aeternity/test.yml
+++ b/ansible/vars/aeternity/test.yml
@@ -1,8 +1,6 @@
 public_ipv4: "{{ ansible_ec2_public_ipv4|default(ansible_ssh_host)|default(ansible_host)|default(inventory_hostname) }}"
 datadog_enabled: no
-api_base_uri: http://{{ public_ipv4 }}:{{ node_config.http.external.port }}/v2
 package: https://s3.eu-central-1.amazonaws.com/aeternity-node-builds/aeternity-latest-ubuntu-x86_64.tar.gz
-configure_peers: true
 seed_peers: []
 db_version: 1
 additional_storage: true

--- a/ansible/vars/aeternity/uat.yml
+++ b/ansible/vars/aeternity/uat.yml
@@ -1,10 +1,7 @@
 public_ipv4: "{{ ansible_ec2_public_ipv4|default(ansible_ssh_host)|default(ansible_host)|default(inventory_hostname) }}"
 datadog_enabled: yes
-api_base_uri: http://{{ public_ipv4 }}:{{ node_config.http.external.port }}/v2
-configure_peers: false
 additional_storage: true
 additional_storage_mountpoint: /data
-
 seed_peers:
   - "52.10.46.160"
   - "18.195.109.60"
@@ -12,11 +9,6 @@ seed_peers:
   - "13.53.161.215"
 
 node_config:
-  peers:
-    - "aenode://pp_QU9CvhAQH56a2kA15tCnWPRJ2srMJW8ZmfbbFTAy7eG4o16Bf@52.10.46.160:3015"
-    - "aenode://pp_2vhFb3HtHd1S7ynbpbFnEdph1tnDXFSfu4NGtq46S2eM5HCdbC@18.195.109.60:3015"
-    - "aenode://pp_27xmgQ4N1E3QwHyoutLtZsHW5DSW4zneQJ3CxT5JbUejxtFuAu@13.250.162.250:3015"
-    - "aenode://pp_DMLqy7Zuhoxe2FzpydyQTgwCJ52wouzxtHWsPGo51XDcxc5c8@13.53.161.215:3015"
   sync:
     port: 3015
 
@@ -33,8 +25,6 @@ node_config:
   chain:
     persist: true
     db_path: "/data/db{{ db_version|mandatory }}"
-    protocol_beneficiaries_enabled: true
-    protocol_beneficiaries: ["ak_2A3PZPfMC2X7ZVy4qGXz2xh2Lbh79Q4UvZ5fdH7QVFocEgcKzU:109"]
 
   mining:
     autostart: true

--- a/ansible/vars/aeternity/uat_mon.yml
+++ b/ansible/vars/aeternity/uat_mon.yml
@@ -1,6 +1,5 @@
 public_ipv4: "{{ ansible_ec2_public_ipv4|default(ansible_ssh_host)|default(ansible_host)|default(inventory_hostname) }}"
 datadog_enabled: yes
-api_base_uri: http://{{ public_ipv4 }}:{{ node_config.http.external.port }}/v2
 monitoring_vault_path: "{{ 'secret/aenode/monitor/uat/' + ansible_ec2_placement_region|default('global') + '/publisher' }}"
 monitoring_pubkey: "{{ lookup('hashi_vault', 'secret=' + monitoring_vault_path + ':pubkey') }}"
 monitoring_privkey: "{{ lookup('hashi_vault', 'secret=' + monitoring_vault_path + ':privkey') }}"


### PR DESCRIPTION
- api_base_uri and configure_peers are not used anymore
- removed node peers configuration of mainnet and testnet nodes as it's
buildin into the node packages
- integration environment do not need seed_peers anymore as it's part of
the testnet
- removed explicit defaults of protocol_beneficiaries