### PR TITLE
Vault node-config repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Make sure to copy the modifications to .dockerignore
 *.retry
 ansible/group_vars/**/*.local.*
+ansible/vars/node_config.*
 ansible/inventory/*.rc.sh
 ansible/callback_plugins/datadog_callback.yml
 .virtualenv/

--- a/ansible/deploy.yml
+++ b/ansible/deploy.yml
@@ -8,6 +8,7 @@
   max_fail_percentage: 25
 
   vars:
+    public_ipv4: "{{ ansible_ec2_public_ipv4|default(ansible_ssh_host)|default(ansible_host)|default(inventory_hostname) }}"
     project_root: "/home/aeternity/node"
     packages_path: "/home/aeternity"
     datadog_api_key: "{{ lookup('hashi_vault', 'secret=secret/datadog/deploy:api_key') }}"

--- a/ansible/deploy.yml
+++ b/ansible/deploy.yml
@@ -60,6 +60,7 @@
       - name: "Load a variable files for environment: {{ env }}"
         include_vars: "{{ item }}"
         with_first_found:
+          - "vars/node_config.yml"
           - "vars/aeternity/{{ env }}.yml"
         tags: [config, node_config, peer_keys, health-check]
 

--- a/ansible/dump-peer-keys.yml
+++ b/ansible/dump-peer-keys.yml
@@ -3,6 +3,9 @@
   remote_user: aeternity
   gather_facts: no
 
+  vars:
+    public_ipv4: "{{ ansible_ec2_public_ipv4|default(ansible_ssh_host)|default(ansible_host)|default(inventory_hostname) }}"
+
   tasks:
     - name: Get the base58c public key
       command: "/home/aeternity/node/bin/aeternity peer_key"

--- a/ansible/ebs-grow-volume.yml
+++ b/ansible/ebs-grow-volume.yml
@@ -24,6 +24,7 @@
       include_vars: "{{ item }}"
       with_first_found:
         - files:
+            - "vars/node_config.yml"
             - "vars/aeternity/{{ env }}.yml"
           skip: true
 

--- a/ansible/health-check.yml
+++ b/ansible/health-check.yml
@@ -13,6 +13,7 @@
     - name: "Load a variable files for environment: {{ env }}"
       include_vars: "{{ item }}"
       with_first_found:
+        - "vars/node_config.yml"
         - "vars/aeternity/{{ env }}.yml"
 
     - name: Run health checks

--- a/ansible/manage-node.yml
+++ b/ansible/manage-node.yml
@@ -22,6 +22,7 @@
     - name: "Load a variable files for environment: {{ env }}"
       include_vars: "{{ item }}"
       with_first_found:
+        - "vars/node_config.yml"
         - "vars/aeternity/{{ env }}.yml"
 
     - name: Aeternity binary exists

--- a/ansible/mnesia_snapshot.yml
+++ b/ansible/mnesia_snapshot.yml
@@ -17,6 +17,7 @@
     - name: "Load a variable files for environment: {{ env }}"
       include_vars: "{{ item }}"
       with_first_found:
+        - "../vars/node_config.yml"
         - "../vars/aeternity/{{ env }}.yml"
       tags: [config, node_config]
 

--- a/ansible/mnesia_snapshot_restore.yml
+++ b/ansible/mnesia_snapshot_restore.yml
@@ -18,6 +18,7 @@
     - name: "Load a variable files for environment: {{ env }}"
       include_vars: "{{ item }}"
       with_first_found:
+        - "../vars/node_config.yml"
         - "../vars/aeternity/{{ env }}.yml"
       tags: [config, node_config]
 

--- a/ansible/tasks/additional_storage.yml
+++ b/ansible/tasks/additional_storage.yml
@@ -16,6 +16,7 @@
   include_vars: "{{ item }}"
   with_first_found:
     - files:
+        - "vars/node_config.yml"
         - "vars/aeternity/{{ env }}.yml"
       skip: true
 

--- a/ansible/vars/aeternity/api_main.yml
+++ b/ansible/vars/aeternity/api_main.yml
@@ -1,4 +1,3 @@
-public_ipv4: "{{ ansible_ec2_public_ipv4|default(ansible_ssh_host)|default(ansible_host)|default(inventory_hostname) }}"
 datadog_enabled: yes
 seed_peers: []
 additional_storage: true

--- a/ansible/vars/aeternity/api_uat.yml
+++ b/ansible/vars/aeternity/api_uat.yml
@@ -1,4 +1,3 @@
-public_ipv4: "{{ ansible_ec2_public_ipv4|default(ansible_ssh_host)|default(ansible_host)|default(inventory_hostname) }}"
 datadog_enabled: yes
 seed_peers: []
 additional_storage: true

--- a/ansible/vars/aeternity/dev1.yml
+++ b/ansible/vars/aeternity/dev1.yml
@@ -1,4 +1,3 @@
-public_ipv4: "{{ ansible_ec2_public_ipv4|default(ansible_ssh_host)|default(ansible_host)|default(inventory_hostname) }}"
 datadog_enabled: yes
 seed_peers: []
 

--- a/ansible/vars/aeternity/dev2.yml
+++ b/ansible/vars/aeternity/dev2.yml
@@ -1,4 +1,3 @@
-public_ipv4: "{{ ansible_ec2_public_ipv4|default(ansible_ssh_host)|default(ansible_host)|default(inventory_hostname) }}"
 datadog_enabled: no
 seed_peers: []
 

--- a/ansible/vars/aeternity/integration.yml
+++ b/ansible/vars/aeternity/integration.yml
@@ -1,4 +1,3 @@
-public_ipv4: "{{ ansible_ec2_public_ipv4|default(ansible_ssh_host)|default(ansible_host)|default(inventory_hostname) }}"
 datadog_enabled: yes
 additional_storage: true
 additional_storage_mountpoint: /data

--- a/ansible/vars/aeternity/main.yml
+++ b/ansible/vars/aeternity/main.yml
@@ -1,4 +1,3 @@
-public_ipv4: "{{ ansible_ec2_public_ipv4|default(ansible_ssh_host)|default(ansible_host)|default(inventory_hostname) }}"
 datadog_enabled: yes
 additional_storage: true
 additional_storage_mountpoint: /data

--- a/ansible/vars/aeternity/main_mon.yml
+++ b/ansible/vars/aeternity/main_mon.yml
@@ -1,4 +1,3 @@
-public_ipv4: "{{ ansible_ec2_public_ipv4|default(ansible_ssh_host)|default(ansible_host)|default(inventory_hostname) }}"
 datadog_enabled: yes
 monitoring_vault_path: "{{ 'secret/aenode/monitor/main/' + ansible_ec2_placement_region|default('global') + '/publisher' }}"
 monitoring_pubkey: "{{ lookup('hashi_vault', 'secret=' + monitoring_vault_path + ':pubkey') }}"

--- a/ansible/vars/aeternity/next.yml
+++ b/ansible/vars/aeternity/next.yml
@@ -1,4 +1,3 @@
-public_ipv4: "{{ ansible_ec2_public_ipv4|default(ansible_ssh_host)|default(ansible_host)|default(inventory_hostname) }}"
 datadog_enabled: yes
 seed_peers: [18.130.100.58]
 

--- a/ansible/vars/aeternity/test.yml
+++ b/ansible/vars/aeternity/test.yml
@@ -1,4 +1,3 @@
-public_ipv4: "{{ ansible_ec2_public_ipv4|default(ansible_ssh_host)|default(ansible_host)|default(inventory_hostname) }}"
 datadog_enabled: no
 package: https://s3.eu-central-1.amazonaws.com/aeternity-node-builds/aeternity-latest-ubuntu-x86_64.tar.gz
 seed_peers: []

--- a/ansible/vars/aeternity/uat.yml
+++ b/ansible/vars/aeternity/uat.yml
@@ -1,4 +1,3 @@
-public_ipv4: "{{ ansible_ec2_public_ipv4|default(ansible_ssh_host)|default(ansible_host)|default(inventory_hostname) }}"
 datadog_enabled: yes
 additional_storage: true
 additional_storage_mountpoint: /data

--- a/ansible/vars/aeternity/uat_mon.yml
+++ b/ansible/vars/aeternity/uat_mon.yml
@@ -1,4 +1,3 @@
-public_ipv4: "{{ ansible_ec2_public_ipv4|default(ansible_ssh_host)|default(ansible_host)|default(inventory_hostname) }}"
 datadog_enabled: yes
 monitoring_vault_path: "{{ 'secret/aenode/monitor/uat/' + ansible_ec2_placement_region|default('global') + '/publisher' }}"
 monitoring_pubkey: "{{ lookup('hashi_vault', 'secret=' + monitoring_vault_path + ':pubkey') }}"

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -23,6 +23,7 @@ done
 
 vault_addr=$(echo $AWS_TAGS | jq -r '.[] | select(.Key == "vault_addr") | .Value')
 vault_role=$(echo $AWS_TAGS | jq -r '.[] | select(.Key == "vault_role") | .Value')
+vault_config=$(echo $AWS_TAGS | jq -r '.[] | select(.Key == "vault_config") | .Value')
 env=$(echo $AWS_TAGS | jq -r '.[] | select(.Key == "env") | .Value')
 aeternity_package=$(echo $AWS_TAGS | jq -r '.[] | select(.Key == "package") | .Value')
 snapshot_filename=$(echo $AWS_TAGS | jq -r '.[] | select(.Key == "snapshot_filename") | .Value')
@@ -57,6 +58,11 @@ export VAULT_TOKEN=$(vault write -field=token auth/aws/login pkcs7=$PKCS7 role=$
 
 cd $(dirname $0)/../ansible/
 ansible-galaxy install -r requirements.yml
+
+# Dump vault stored config vars if exist as file that will be included in playbooks
+if [[ ! -z "$vault_config" ]]; then
+    vault read secret/$(vault_config) > vars/node_config.yml
+fi
 
 # While Ansible is run by Python 3 because of the virtual environment
 # the "remote" (which is in this case the same) host interpreter must also be set to python3


### PR DESCRIPTION
Introducing a new way of specifying node configurations that could be controlled per host and is not bound to infrastructure releases.
It uses the Vault as central config repository (requires proper permissions):
1. AWS instances may contain tag `vault_config` which points to a vault key path in the 'secret' store. It should contain a yml configuration. The path should resolve to the contents of .yml vars file.
2. The content will be dumped as `vars/node_config.yml` if the key (or tag itself) exists. This step allows manual overrides (file is not tracked) in case node is not AWS. So it could be generated by other sources.
3. This file will be included in playbooks only if exists or else `vars/<<env>>.yml` will be used as fallback (BC).

in scope of https://www.pivotaltracker.com/story/show/167670648