### PR TITLE
Fix snapshots on master

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ reset-net: check-deploy-env secrets vault-config-$(DEPLOY_ENV)
 		-e "@$(CONFIG_OUTPUT_DIR)/$(DEPLOY_ENV).yml" \
 		reset-net.yml
 
-mnesia_snapshot: secrets vault-config-$(DEPLOY_ENV)
+mnesia_snapshot: secrets vault-config-$(BACKUP_ENV)
 ifeq ($(BACKUP_DB_VERSION),)
 	$(error BACKUP_DB_VERSION should be provided)
 endif


### PR DESCRIPTION
Currently a bug with vault-config is stopping CI snapshots.
This is a fix before the refactoring of Makefile #440 is merged