### PR TITLE
Bootstrapping a node don't get it's config from Vault

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -62,8 +62,8 @@ if [[ -f "${env_config}" ]]; then
 fi
 
 # Override the env defaults with ones stored in $vault_config
-if [[ -n "$(node_config)" && "$(node_config)" != "none" ]]; then
-    vault read $(node_config) -field=node_config > /tmp/node_config.yml
+if [[ -n "${node_config}" && "${node_config}" != "none" ]]; then
+    vault read ${node_config} -field=node_config > /tmp/node_config.yml
 fi
 
 ###


### PR DESCRIPTION
fix #457 