### PR TITLE
Use zstd compression for snapshots

### DIFF
--- a/ansible/mnesia_snapshot.yml
+++ b/ansible/mnesia_snapshot.yml
@@ -7,7 +7,7 @@
 
   vars:
     snapshot_suffix: snapshot
-    snapshot_filename: "mnesia_{{ env }}_v-{{ db_version }}_{{ ansible_ssh_host|default(inventory_hostname) }}_{{ snapshot_suffix }}.tgz"
+    snapshot_filename: "mnesia_{{ env }}_v-{{ db_version }}_{{ ansible_ssh_host|default(inventory_hostname) }}_{{ snapshot_suffix }}.tar.zst"
     snapshot_path: "{{ snapshots_dir|default('/tmp/snapshots') }}/{{ snapshot_filename }}"
     snapshot_checksum_path: "{{ snapshot_path }}.md5"
     aws_access_key: "{{ lookup('env','AWS_ACCESS_KEY_ID') }}"
@@ -64,17 +64,15 @@
       - name: Start archive
         block:
           - name: Archive Mnesia Directory ({{ project_root }}/{{ node_config.chain.db_path }})
-            archive:
-              format: gz
-              path: "{{ project_root }}/{{ node_config.chain.db_path }}"
-              dest: "{{ snapshot_path }}"
+            command:
+              cmd: tar -c -I zstd -f {{ snapshot_path }} {{ project_root }}/{{ node_config.chain.db_path }}
+              creates:  "{{ snapshot_path }}"
             when: additional_storage is not defined or not additional_storage
 
           - name: Archive Mnesia Directory ({{ node_config.chain.db_path }})
-            archive:
-              format: gz
-              path: "{{ node_config.chain.db_path }}"
-              dest: "{{ snapshot_path }}"
+            command:
+              cmd: tar -c -I zstd -f {{ snapshot_path }} {{ node_config.chain.db_path }}
+              creates:  "{{ snapshot_path }}"
             when:
               - additional_storage is defined
               - additional_storage

--- a/ansible/mnesia_snapshot_restore.yml
+++ b/ansible/mnesia_snapshot_restore.yml
@@ -80,10 +80,9 @@
     - meta: flush_handlers
 
     - name: Restore Mnesia database to {{ restore_dir }}/
-      unarchive:
-        remote_src: yes
-        src: "{{ snapshot_path }}"
-        dest: "{{ restore_dir }}/"
+      command:
+        cmd: tar -I zstd -x -f {{ snapshot_path }} -C {{ restore_dir }}/
+        creates:  "{{ node_config.chain.db_path }}"
       notify: "start aeternity daemon"
       when: should_restore
 

--- a/ansible/mnesia_snapshot_restore.yml
+++ b/ansible/mnesia_snapshot_restore.yml
@@ -85,6 +85,8 @@
         creates:  "{{ node_config.chain.db_path }}"
       notify: "start aeternity daemon"
       when: should_restore
+      tags:
+        - skip_ansible_lint
 
     - name: Create restore marker
       file:

--- a/ansible/setup.yml
+++ b/ansible/setup.yml
@@ -79,6 +79,7 @@
         - unzip
         - bc
         - curl
+        - zstd
       tags:
         - dev-tools
 

--- a/ansible/vars/snapshot.yml
+++ b/ansible/vars/snapshot.yml
@@ -1,6 +1,6 @@
 project_root: "{{ ansible_env.HOME }}/node"
 aeternity_bin: "{{ ansible_env.HOME }}/node/bin/aeternity"
 snapshots_bucket: aeternity-database-backups
-snapshots_filename_latest: "mnesia_{{ env }}_v-{{ db_version }}_latest.tgz"
+snapshots_filename_latest: "mnesia_{{ env }}_v-{{ db_version }}_latest.tar.zst"
 restore_snapshot_filename: "{{ snapshots_filename_latest }}" # default for BC
 snapshots_dir: "{{ additional_storage_mountpoint|default('/tmp') }}/snapshots"


### PR DESCRIPTION
closes #496 

Much better initial results:
```
time tar -c -z -v -f db1.tar.gz db1/

real    41m23.931s
user    40m26.856s
sys 1m57.360s

time tar -c -I zstd -v -f db1.tar.zst db1/

real    12m34.586s
user    10m52.916s
sys 1m44.692s


-rw-rw-r--  1 aeternity aeternity  45G Mar 24 11:18 db1.tar.gz
-rw-rw-r--  1 aeternity aeternity  33G Mar 24 11:38 db1.tar.zst

time tar -I zstd -x -f db1.tar.zst -C /data/test/

real    6m17.409s
user    1m34.520s
sys 2m7.320s

```